### PR TITLE
Support RBAC for debugging-user kubernetes access w/ edgeview

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -24,6 +24,7 @@ COPY kubevirt-operator.yaml /etc
 COPY kubevirt-features.yaml /etc
 COPY config-k3s.toml /etc/containerd/
 COPY longhorn-config.yaml /etc/
+COPY debuguser-role-binding.yaml /etc/
 RUN mkdir -p /etc/rancher/k3s
 COPY config.yaml /etc/rancher/k3s
 WORKDIR /

--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -1,0 +1,63 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vm-read-access
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachineinstances/vnc
+      - virtualmachineinstances/console
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+      - virtualmachineinstancepresets
+      - virtualmachineinstancereplicasets
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vm-read-access-binding
+subjects:
+- kind: User
+  name: debugging-user
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: vm-read-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: debugging-cluster-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: debugging-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: debugging-cluster-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: debugging-user


### PR DESCRIPTION
- create debugging-user for kubernetes cluster
- define roles for get,list only for kubernetes resources
- define roles for kubevirt for vm/vmi/console/vnc resource
- binding debugging-user to the cluster roles
- using edgeview to transport the user kubeconfig to user laptop