### PR TITLE
filter kubernetes logs with only warning and error for uploading

### DIFF
--- a/pkg/kube/multus-daemonset.yaml
+++ b/pkg/kube/multus-daemonset.yaml
@@ -179,7 +179,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: naimingshen/multus:latest
+        image: ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=/tmp/multus-conf/00-multus.conf"

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -616,6 +616,13 @@ func getMemlogMsg(logChan chan inputEntry, panicFileChan chan []byte) {
 		if logInfo.Pid != 0 {
 			pidStr = strconv.Itoa(logInfo.Pid)
 		}
+
+		// only allow container 'kube' logging with warning or error to upload
+		if logInfo.Source == "kube" {
+			if logInfo.Level == "" || (logInfo.Level != "warning" && logInfo.Level != "error") {
+				continue
+			}
+		}
 		entry := inputEntry{
 			source:    logInfo.Source,
 			content:   logInfo.Msg,


### PR DESCRIPTION
- in newlogd, have a filter to only allow 'warning'/'error' messages from container kube to upload
- forgot to remove private docker image of 'multus'