### PR TITLE
decouple zedmanager from zedrouter for continue app domain creation

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
 #FROM lfedge/eve-alpine:12487b9900ba40f3ecdadfec2c84799fa34e5014 as build
-FROM lfedge/eve-alpine:4db5153da77be2fed4404d1d62c9c920cb22c308 as build
+#FROM lfedge/eve-alpine:4db5153da77be2fed4404d1d62c9c920cb22c308 as build
+FROM lfedge/eve-alpine:d5974d1fa86fc1517075453cc5b51c7b3299116d as build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep cni-plugins \

--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -112,12 +112,13 @@ func lookupAppNetworkStatus(ctx *zedmanagerContext, key string) *types.AppNetwor
 }
 
 func publishAppNetworkConfig(ctx *zedmanagerContext,
-	status *types.AppNetworkConfig) {
+	config *types.AppNetworkConfig) {
 
-	key := status.Key()
+	key := config.Key()
 	log.Functionf("publishAppNetworkConfig(%s)", key)
 	pub := ctx.pubAppNetworkConfig
-	pub.Publish(key, *status)
+	pub.Publish(key, *config)
+	ctx.anStatusChan <- key
 }
 
 func unpublishAppNetworkConfig(ctx *zedmanagerContext, uuidStr string) {

--- a/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
+++ b/pkg/pillar/cmd/zedrouter/pubsubhandlers.go
@@ -528,11 +528,11 @@ func (z *zedrouter) handleAppNetworkCreate(ctxArg interface{}, key string,
 		}
 	}
 	if !foundAkStatus {
-		z.log.Noticef("handleAppNetworkCreate: AkStatus not found pub anyway")
+		z.log.Noticef("handleAppNetworkCreate: AkStatus not found, wait")
 		status.Activated = true
 		status.PendingAdd = false
 		status.PendingModify = false
-		z.publishAppNetworkStatus(&status)
+		//z.publishAppNetworkStatus(&status)
 
 		return
 	}


### PR DESCRIPTION
- from design doc review comment by Milan, it is better to decouple
  the zedmanager from zedrouter's AppNetworkStatus message in
  order to continue with the Domain creation work.