### PR TITLE
Handle container launch as a VM

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -150,8 +150,8 @@ function set_rootfs_title {
 }
 
 function set_generic {
-   set_global hv_dom0_cpu_settings "dom0_max_vcpus=1 dom0_vcpus_pin"
-   set_global hv_eve_cpu_settings "eve_max_vcpus=1"
+   set_global hv_dom0_cpu_settings "dom0_max_vcpus=2 dom0_vcpus_pin"
+   set_global hv_eve_cpu_settings "eve_max_vcpus=2"
    #temporarily increase memory settings for kubevirt
    if [ "$eve_flavor" = "kubevirt" ]; then
       set_global hv_dom0_mem_settings "dom0_mem=8000M,max:8000M"
@@ -162,7 +162,7 @@ function set_generic {
       set_global hv_eve_mem_settings "eve_mem=650M,max:650M"
       set_global hv_ctrd_mem_settings "ctrd_mem=400M,max:400M"
    fi
-   set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=1"
+   set_global hv_ctrd_cpu_settings "ctrd_max_vcpus=2"
    set_global hv_platform_tweaks "smt=false"
    set_global hv_watchdog_timer "change=500"
    set_global hv_extra_args "$hv_extra_args"

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -426,6 +426,14 @@ if [ ! -f /var/lib/all_components_initialized ]; then
 
                 #Add feature gates
                 kubectl apply -f /etc/kubevirt-features.yaml
+
+                # NOTE: https://kubevirt.io/user-guide/virtual_machines/boot_from_external_source/
+                # Install external-boot-image image to our containerd registry.
+                # This image contains just kernel and initrd to bootstrap a container image as a VM.
+                # This is very similar to what we do on kvm based eve to start container as a VM.
+                # NOTE: This image in public repo is just a workaround. We need to figure out a proper way to get this 
+                # installed into eve containerd repository (may be at build time ?)
+                ctr  -a /run/containerd-user/containerd.sock -n k8s.io  image pull docker.io/zededapramodh/external-boot-scratch-container:2.0
                 touch /var/lib/kubevirt_initialized
         fi
 

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -124,7 +124,7 @@ ENV BUILD_PKGS patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptables ip6tables iproute2 dhcpcd \
     coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso \
     qemu-img jq e2fsprogs-extra keyutils ca-certificates ip6tables-openrc iptables-openrc ipset-openrc hdparm \
-    libintl libtirpc libblkid zlib
+    libintl libtirpc libblkid zlib rsync
 RUN eve-alpine-deploy.sh
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
@@ -154,6 +154,7 @@ ADD scripts/device-steps.sh \
     scripts/handlezedserverconfig.sh \
     scripts/veth.sh \
     scripts/dhcpcd.sh \
+    scripts/create-image-to-qcow.sh \
   /out/opt/zededa/bin/
 ADD conf/lisp.config.base /out/var/tmp/zededa/lisp.config.base
 

--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -709,8 +710,9 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, rootBlobSha
 	cmd := clientImageSpec.Config.Cmd
 	workdir := clientImageSpec.Config.WorkingDir
 	unProcessedEnv := clientImageSpec.Config.Env
-	logrus.Infof("PrepareContainerRootDir: mountPoints %+v execpath %+v cmd %+v workdir %+v env %+v",
-		mountpoints, execpath, cmd, workdir, unProcessedEnv)
+	user := clientImageSpec.Config.User
+	logrus.Infof("PrepareContainerRootDir: mountPoints %+v execpath %+v cmd %+v workdir %+v env %+v user %+v",
+		mountpoints, execpath, cmd, workdir, unProcessedEnv, user)
 	clientImageSpecJSON, err := getJSON(clientImageSpec)
 	if err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Could not build json of image: %v. %v",
@@ -729,6 +731,84 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, rootBlobSha
 			rootPath, imageConfigFilename, err)
 		logrus.Errorf(err.Error())
 		return err
+	}
+
+	// On kubevirt eve we also write the mountpoints and cmdline files to the rootPath.
+	// Once rootPath is populated with all necessary files, this rootPath directory will be
+	// converted to a PVC and passed in to domainmgr to attach to VM as rootdisk
+	// NOTE: For kvm eve these files are generated and passed to bootloader in pkg/pillar/containerd/oci.go:AddLoader()
+	if base.IsHVTypeKube() {
+
+		// Mount the snapshot
+		if err := c.MountSnapshot(snapshotID, GetRoofFsPath(rootPath)); err != nil {
+			return fmt.Errorf("PrepareContainerRootDir error mount of snapshot: %s. %s", snapshotID, err)
+		}
+
+		for m := range mountpoints {
+
+			b := []byte(fmt.Sprintf("%+v\n", m))
+			if err := os.WriteFile(filepath.Join(rootPath, "mountPoints"), b, 0666); err != nil {
+				err = fmt.Errorf("PrepareContainerRootDir: Exception while writing mountpoints to %v %v",
+					rootPath, err)
+				logrus.Errorf(err.Error())
+				return err
+			}
+		}
+
+		// create env manifest
+		envContent := ""
+		if workdir != "" {
+			envContent = fmt.Sprintf("export WORKDIR=\"%s\"\n", workdir)
+		} else {
+			envContent = fmt.Sprintf("export WORKDIR=/\n")
+		}
+		for _, e := range unProcessedEnv {
+			keyAndValueSlice := strings.SplitN(e, "=", 2)
+			if len(keyAndValueSlice) == 2 {
+				//handles Key=Value case
+				envContent = envContent + fmt.Sprintf("export %s=\"%s\"\n", keyAndValueSlice[0], keyAndValueSlice[1])
+			} else {
+				//handles Key= case
+				envContent = envContent + fmt.Sprintf("export %s\n", e)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(rootPath, "environment"), []byte(envContent), 0644); err != nil {
+			return err
+		}
+
+		// create cmdline manifest
+		// each item needs to be independently quoted for initrd
+		execpathQuoted := make([]string, 0)
+
+		// This loop is just to pick the execpath and eliminate any square braces around it.
+		// Just pick /entrypoint.sh from [/entrypoint.sh]
+		for _, c := range execpath {
+			execpathQuoted = append(execpathQuoted, fmt.Sprintf("\"%s\"", c))
+		}
+		for _, s := range cmd {
+			execpathQuoted = append(execpathQuoted, fmt.Sprintf("\"%s\"", s))
+		}
+		command := strings.Join(execpathQuoted, " ")
+		if err := os.WriteFile(filepath.Join(rootPath, "cmdline"),
+			[]byte(command), 0644); err != nil {
+			return err
+		}
+
+		// Userid and GID are same
+		ug := fmt.Sprintf("%d %d", 0, 0)
+		if user != "" {
+			uid, _ := strconv.Atoi(user)
+			ug = fmt.Sprintf("%d %d", uid, uid)
+		}
+		if err := os.WriteFile(filepath.Join(rootPath, "ug"),
+			[]byte(ug), 0644); err != nil {
+			return err
+		}
+
+		if err := os.MkdirAll(filepath.Join(rootPath, "modules"), 0600); err != nil {
+			return err
+		}
+
 	}
 	return nil
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1484,13 +1484,17 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 		case zconfig.Format_FmtUnknown:
 			// do nothing
 		case zconfig.Format_CONTAINER:
-			snapshotID := containerd.GetSnapshotID(ds.FileLocation)
-			if err := ctx.casClient.MountSnapshot(snapshotID, cas.GetRoofFsPath(ds.FileLocation)); err != nil {
-				err := fmt.Errorf("doActivate: Failed mount snapshot: %s for %s. Error %s",
-					snapshotID, config.UUIDandVersion.UUID, err)
-				log.Error(err.Error())
-				status.SetErrorNow(err.Error())
-				return
+			// In Kubevirt eve container image is converted to PVC in volumemgr, there is nothing to mount here.
+			if !ctx.hvTypeKube {
+
+				snapshotID := containerd.GetSnapshotID(ds.FileLocation)
+				if err := ctx.casClient.MountSnapshot(snapshotID, cas.GetRoofFsPath(ds.FileLocation)); err != nil {
+					err := fmt.Errorf("doActivate: Failed mount snapshot: %s for %s. Error %s",
+						snapshotID, config.UUIDandVersion.UUID, err)
+					log.Error(err.Error())
+					status.SetErrorNow(err.Error())
+					return
+				}
 			}
 		default:
 			// assume everything else to be disk formats

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -482,22 +482,24 @@ func unpublishBlobStatus(ctx *volumemgrContext, blobs ...*types.BlobStatus) {
 
 		// If this Blob is not downloaded by eve, ignore and continue
 		// In kubevirt eve, k3s specific images,blobs are not downloaded by eve.
-		if base.IsHVTypeKube() {
-			blobInfo, err := ctx.casClient.GetBlobInfo(cas.CheckAndCorrectBlobHash(blob.Sha256))
-			if err != nil {
-				err := fmt.Errorf("unpublishBlobStatus: Exception while getting blob info %s: %s",
-					blob.Sha256, err.Error())
-				log.Errorf(err.Error())
-				continue
-			}
-			label := blobInfo.Labels
-			_, found := label["eve-downloaded"]
-			if !found {
-				log.Noticef("unplublishBlobStatus: PRAMOD Ignoring the blob %s not downloaded by eve", blob.Sha256)
-				continue
-			}
+		/*
+			if base.IsHVTypeKube() {
+				blobInfo, err := ctx.casClient.GetBlobInfo(cas.CheckAndCorrectBlobHash(blob.Sha256))
+				if err != nil {
+					err := fmt.Errorf("unpublishBlobStatus: Exception while getting blob info %s: %s",
+						blob.Sha256, err.Error())
+					log.Errorf(err.Error())
+					continue
+				}
+				label := blobInfo.Labels
+				_, found := label["eve-downloaded"]
+				if !found {
+					log.Noticef("unplublishBlobStatus: PRAMOD Ignoring the blob %s not downloaded by eve", blob.Sha256)
+					continue
+				}
 
-		}
+			}
+		*/
 
 		// Drop references. Note that we never publish the resulting
 		// BlobStatus since we unpublish it below.
@@ -619,33 +621,33 @@ func gcImagesFromCAS(ctx *volumemgrContext) {
 	}
 
 	for _, image := range casImages {
-		//if _, ok := referenceMap[image]; !ok {
+		if _, ok := referenceMap[image]; !ok {
 
-		// In kubevirt eve k3s specific containers are not downloaded by EVE.
-		// We cannot garbage collect those, so make sure this image was actually downloaded
-		// by eve, by checking label eve_downloaded=true
-		if base.IsHVTypeKube() {
-			label, err := ctx.casClient.GetImageLabel(image)
-			if err != nil {
-				log.Errorf("gcImagesFromCAS: error while getting image label from ctr %s", err)
-				continue
-			}
-			_, found := label["eve-downloaded"]
-			if found {
-				// Garbage this image since it was downloaded by eve and not referenced.
-				log.Noticef("gcImagesFromCAS: PRAMOD removing image %s from CAS since no ContentTreeStatus ref found, label %v", image, label)
-				//if err := ctx.casClient.RemoveImage(image); err != nil {
-				//	log.Errorf("gcImagesFromCAS: Exception while removing image from CAS. %s", err)
-				//}
-			}
-		} else {
-			log.Functionf("gcImagesFromCAS: PRAMOD else removing image %s from CAS since no ContentTreeStatus ref found", image)
-			//if err := ctx.casClient.RemoveImage(image); err != nil {
-			//	log.Errorf("gcImagesFromCAS: Exception while removing image from CAS. %s", err)
-			//}
+			// In kubevirt eve k3s specific containers are not downloaded by EVE.
+			// We cannot garbage collect those, so make sure this image was actually downloaded
+			// by eve, by checking label eve_downloaded=true
+			if base.IsHVTypeKube() {
+				label, err := ctx.casClient.GetImageLabel(image)
+				if err != nil {
+					log.Errorf("gcImagesFromCAS: error while getting image label from ctr %s", err)
+					continue
+				}
+				_, found := label["eve-downloaded"]
+				if found {
+					// Garbage this image since it was downloaded by eve and not referenced.
+					log.Noticef("gcImagesFromCAS: PRAMOD removing image %s from CAS since no ContentTreeStatus ref found, label %v", image, label)
+					if err := ctx.casClient.RemoveImage(image); err != nil {
+						log.Errorf("gcImagesFromCAS: Exception while removing image from CAS. %s", err)
+					}
+				}
+			} else {
+				log.Functionf("gcImagesFromCAS: PRAMOD else removing image %s from CAS since no ContentTreeStatus ref found", image)
+				if err := ctx.casClient.RemoveImage(image); err != nil {
+					log.Errorf("gcImagesFromCAS: Exception while removing image from CAS. %s", err)
+				}
 
+			}
 		}
-		//}
 	}
 }
 

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -712,9 +712,16 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 // gcUnusedInitObjects this method will garbage collect all unused resource during init
 func gcUnusedInitObjects(ctx *volumemgrContext) {
 	log.Functionf("gcUnusedInitObjects")
-	gcBlobStatus(ctx)
-	gcVerifyImageConfig(ctx)
-	gcImagesFromCAS(ctx)
+
+	// TODO: Need to handle GC for kubevirt eve
+	// There are images and blobs downloaded by kubernetes and eve is not aware of those
+	// We use same containerd repository to store those images.
+	// so for now block GC until we find a proper solution
+	if !ctx.hvTypeKube {
+		gcBlobStatus(ctx)
+		gcVerifyImageConfig(ctx)
+		gcImagesFromCAS(ctx)
+	}
 }
 
 func handleVerifierRestarted(ctxArg interface{}, restartCounter int) {

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -271,15 +271,39 @@ func (ctx kubevirtContext) CreateVMIConfig(domainName string, config types.Domai
 	vmi.Spec.Networks = nads
 	vmi.Spec.Domain.Devices.Interfaces = intfs
 
+	// First check the diskStatusList and ignore 9P
 	// Set Storage
 	if len(diskStatusList) > 0 {
 		disks := make([]v1.Disk, len(diskStatusList))
 		vols := make([]v1.Volume, len(diskStatusList))
-
+		ndisks := len(diskStatusList)
 		for i, ds := range diskStatusList {
 
 			diskName := "disk" + strconv.Itoa(i+1)
-			if ds.Devtype == "cdrom" {
+
+			// Domainmgr sets devtype 9P for container images. Though in kubevirt container image is
+			// converted to PVC and will not use 9P protocol, but we still use this dev type to launch a
+			// external bootable container.
+			if ds.Devtype == "9P" {
+				// kvm based EVE supports launching a container as VM. It generates a runtime ocispec and passes in
+				// kernel and initrd along with other generated files.
+				// The concept is same in kubevirt eve too. Kubevirt supports this functionality through feature
+				// https://kubevirt.io/user-guide/virtual_machines/boot_from_external_source/
+				// We need to have a prebuilt scratch image and pass in the path of kernel, initrd and any kernel args in the vmi spec we are generating.
+				// TODO: eve build generates this scratch image. For now its hardcoded.
+
+				// Since disks are virtio disks we assume /dev/vda is the boot disk
+				kernel_args := "console=tty0 root=/dev/vda dhcp=1 rootfstype=ext4"
+				scratch_image := "docker.io/zededapramodh/external-boot-scratch-container:2.0"
+				kernel_path := "/kernel"
+				initrd_path := "/runx-initrd"
+
+				addKernelBootContainer(&vmi.Spec, scratch_image, kernel_args, kernel_path, initrd_path)
+
+				// We don't set this disk to vmi spec
+				ndisks = ndisks - 1
+
+			} else if ds.Devtype == "cdrom" {
 				disks[i] = v1.Disk{
 					Name: diskName,
 					DiskDevice: v1.DiskDevice{
@@ -319,8 +343,8 @@ func (ctx kubevirtContext) CreateVMIConfig(domainName string, config types.Domai
 			}
 
 		}
-		vmi.Spec.Domain.Devices.Disks = disks
-		vmi.Spec.Volumes = vols
+		vmi.Spec.Domain.Devices.Disks = disks[0:ndisks]
+		vmi.Spec.Volumes = vols[0:ndisks]
 	}
 
 	// Gather all PCI assignments into a single line
@@ -1355,4 +1379,22 @@ func CleanupStaleVMI() (int, error) {
 		count++
 	}
 	return count, nil
+}
+
+func addKernelBootContainer(spec *v1.VirtualMachineInstanceSpec, image, kernelArgs, kernelPath, initrdPath string) *v1.VirtualMachineInstanceSpec {
+	if spec.Domain.Firmware == nil {
+		spec.Domain.Firmware = &v1.Firmware{}
+	}
+
+	spec.Domain.Firmware.KernelBoot = &v1.KernelBoot{
+		KernelArgs: kernelArgs,
+		Container: &v1.KernelBootContainer{
+			Image:           image,
+			KernelPath:      kernelPath,
+			InitrdPath:      initrdPath,
+			ImagePullPolicy: k8sv1.PullNever,
+		},
+	}
+
+	return spec
 }

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -181,8 +181,9 @@ func NewPVCDefinition(pvcName string, size string, annotations, labels map[strin
 	}
 }
 
-// RolloutImgToPVC copy the content of diskfile to PVC
-func RolloutImgToPVC(ctx context.Context, log *base.LogObject, exists bool, diskfile string, pvcName string, isAppImage bool) error {
+// RolloutDiskToPVC copy the content of diskfile to PVC
+// diskfile can be in qcow or raw format
+func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool, diskfile string, pvcName string, filemode bool) error {
 
 	//fetch CDI proxy url
 	// Get the Kubernetes clientset
@@ -203,7 +204,7 @@ func RolloutImgToPVC(ctx context.Context, log *base.LogObject, exists bool, disk
 				return errors.New(errStr)
 			}
 			time.Sleep(10 * time.Second)
-			log.Noticef("PRAMOD RolloutImgToPVC loop (%d), wait for 10 sec, err %v", i, err)
+			log.Noticef("PRAMOD RolloutDiskToPVC loop (%d), wait for 10 sec, err %v", i, err)
 		} else {
 			break
 		}
@@ -213,7 +214,7 @@ func RolloutImgToPVC(ctx context.Context, log *base.LogObject, exists bool, disk
 	// Get the ClusterIP of the Service.
 	clusterIP := service.Spec.ClusterIP
 	uploadproxyURL := "https://" + clusterIP + ":443"
-	log.Noticef("PRAMOD RolloutImgToPVC diskfile %s pvc %s  URL %s", diskfile, pvcName, uploadproxyURL)
+	log.Noticef("PRAMOD RolloutDiskToPVC diskfile %s pvc %s  URL %s", diskfile, pvcName, uploadproxyURL)
 	volSize, err := diskmetrics.GetDiskVirtualSize(log, diskfile)
 	if err != nil {
 		errStr := fmt.Sprintf("Failed to get virtual size of disk %s: %v", diskfile, err)
@@ -230,18 +231,27 @@ func RolloutImgToPVC(ctx context.Context, log *base.LogObject, exists bool, disk
 		volSize = actualVolSize
 	}
 
+	//TODO: Delete this later, just a overhead allocation to be sure
+	overhead := volSize / 10
+	if overhead < (10 * 1024 * 1024) {
+		overhead = 10 * 1024 * 1024
+	}
+
+	volSize = volSize + overhead
+
 	// virtctl image-upload -n eve-kube-app pvc a1030350-bd03-4b79-ac1c-4d8564d0e4b0-pvc-0   --no-create --storage-class longhorn --image-path=/persist/vault/containerd/io.containerd.content.v1.content/blobs/sha256/
 	// 84ed078f3f0e1671d591d15409883a24bd30763eb10a9dec01a2fb38cf06cf6d --insecure --uploadproxy-url https://10.43.31.180:8443
 	// Write API to get proxy url
 
 	args := []string{"image-upload", "-n", "eve-kube-app", "pvc", pvcName, "--storage-class", "longhorn", "--image-path", diskfile, "--insecure", "--uploadproxy-url", uploadproxyURL, "--kubeconfig", kubeConfigFile}
 
-	// We create PVC of filesystem mode if its appimage volume. longhorn PVC FS mode does not support ReadWriteMany mode.
-	if isAppImage {
-		args = append(args, "--access-mode", "ReadWriteOnce")
-	} else {
-		args = append(args, "--access-mode", "ReadWriteMany", "--block-volume")
+	args = append(args, "--access-mode", "ReadWriteOnce")
+
+	if !filemode {
+		args = append(args, "--block-volume")
 	}
+
+	//args = append(args, "--access-mode", "ReadWriteMany", "--block-volume")
 	//args := fmt.Sprintf("image-upload -n eve-kube-app pvc %s --no-create --storage-class longhorn --image-path=%s --insecure --uploadproxy-url %s", outputFile, diskfile, uploadproxyURL)
 
 	// If PVC already exists just copy out the data, else virtctl will create the PVC before data copy
@@ -251,14 +261,22 @@ func RolloutImgToPVC(ctx context.Context, log *base.LogObject, exists bool, disk
 		// Add size
 		args = append(args, "--size", fmt.Sprint(volSize))
 	}
-	time.Sleep(10 * time.Second)
+
 	log.Noticef("PRAMOD virtctl args %v", args)
 
 	output, err := base.Exec(log, "/containers/services/kube/rootfs/usr/bin/virtctl", args...).WithContext(ctx).WithUnlimitedTimeout(432000 * time.Second).CombinedOutput()
-	log.Noticef("RolloutImgToPVC: image-upload error %v", err)
-	log.Noticef("RolloutImgToPVC: image-upload output %s", output)
+
+	if err != nil {
+		errStr := fmt.Sprintf("RolloutDiskToPVC: Failed to convert qcow to PVC  %s: %v", output, err)
+		return errors.New(errStr)
+	}
 	err = waitForPVCReady(ctx, log, pvcName)
-	log.Noticef("RolloutImgToPVC: wait for pvc %v", err)
+
+	if err != nil {
+		errStr := fmt.Sprintf("RolloutDiskToPVC: error wait for PVC %v", err)
+		return errors.New(errStr)
+	}
+
 	return nil
 }
 

--- a/pkg/pillar/scripts/create-image-to-qcow.sh
+++ b/pkg/pillar/scripts/create-image-to-qcow.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+echo "$(date -Ins -u) Starting create-image-to-qcow.sh"
+
+SRCDIR=$1
+DESTFILE=$2
+#SIZE=$3
+MOUNTDIR=/tmp/dest.$$
+
+if [ ! -d $SRCDIR ]; then
+   echo "$SRCDIR does not exist"
+   exit 1
+fi
+
+if [ -f $DESTFILE ]; then
+   echo "$DESTFILE already exists"
+   exit 1
+fi
+
+SIZEMB=`du -sm $SRCDIR/ | awk '{print $1}'`
+# This is to account ext4 metadata, approx 8MB per 128MB of disksize
+#((NSEGS = 1 + SIZEMB / 128))
+#((METADATASIZEMB = NSEGS * 8))
+#((SIZEMB = SIZEMB + METADATASIZEMB))
+SIZEMB=$((SIZEMB * 2))
+/usr/bin/qemu-img create -o preallocation=off -f qcow2 $DESTFILE $SIZEMB"M"
+qemu-img info -U --output=json $DESTFILE
+#Get an exclusive lock so that no one else mounts the /dev/nbd10      
+LOCK_FILE="/run/create-image.lock"                                     
+                                                                      
+WAIT_INTERVAL=5                                                       
+# Loop until an exclusive lock is acquired                            
+while true; do                                                        
+    exec 200>"$LOCK_FILE"                                             
+    if flock -x 200; then                                             
+        break  # Exit the loop if the lock is acquired                
+    else                                                        
+        echo "Waiting for exclusive lock..."                    
+        sleep "$WAIT_INTERVAL"                                  
+    fi                                                
+done    
+
+# Set up ndb to mount qcow file.              
+modprobe nbd max_part=8                       
+/usr/bin/qemu-nbd --connect=/dev/nbd10 $DESTFILE
+sleep 10
+mke2fs -t ext4 /dev/nbd10                     
+qemu-img info -U --output=json $DESTFILE
+mkdir -p $MOUNTDIR 
+mount -t ext4 /dev/nbd10 $MOUNTDIR 
+failed=0                          
+                                  
+echo "Starting rsync"             
+#Use rsync to keep source permissions and ownership
+rsync -arl  $SRCDIR/* $MOUNTDIR 
+if [ $? -ne 0 ]; then                           
+failed=1                                        
+fi                                              
+umount $MOUNTDIR 
+qemu-nbd --disconnect /dev/nbd10                
+rm -rf $MOUNTDIR
+flock -u 200                                    
+if [ "$failed" = "1" ]; then                                          
+echo "Failed to copy to qcow2 file $DESTFILE, deleting it"   
+exit 1                                                                
+fi                                                                    
+echo "rsync succeeded"                                                
+qemu-img info -U --output=json $DESTFILE
+echo "$(date -Ins -u) Converted $SRCDIR to $DESTFILE"                 
+exit 0                                                  

--- a/pkg/pillar/volumehandlers/handlers.go
+++ b/pkg/pillar/volumehandlers/handlers.go
@@ -62,14 +62,14 @@ func useVhost(log *base.LogObject, volumeManager VolumeMgr) bool {
 // GetVolumeHandler returns handler based on provided status
 func GetVolumeHandler(log *base.LogObject, volumeManager VolumeMgr, status *types.VolumeStatus) VolumeHandler {
 	common := commonVolumeHandler{volumeManager: volumeManager, status: status, log: log}
+
+	if base.IsHVTypeKube() {
+		return &volumeHandlerCSI{commonVolumeHandler: common, useVHost: false} // kubevirt does not support vhost yet
+	}
 	if status.IsContainer() {
 		return &volumeHandlerContainer{common}
 	}
-	// We always check for kubevirt type before ZFS since we use ZFS for non-kubevirt types too.
-	// That is, Persist type could be ZFS but the eve flavor is kubevirt
-	if base.IsHVTypeKube() {
-		return &volumeHandlerCSI{commonVolumeHandler: common, useVHost: false} // kubevirt does not support vhost yet
-	} else if status.UseZVolDisk(vault.ReadPersistType()) {
+	if status.UseZVolDisk(vault.ReadPersistType()) {
 		return &volumeHandlerZVol{commonVolumeHandler: common, useVHost: useVhost(log, volumeManager)}
 	}
 	return &volumeHandlerFile{common}

--- a/pkg/xen-tools/initrd/mount_disk.sh
+++ b/pkg/xen-tools/initrd/mount_disk.sh
@@ -4,8 +4,14 @@
 # and in /mnt/mountPoints file (where mount points defined)
 
 mountPointLineNo=1
+rootdisk=`cat /proc/cmdline  | grep -o '\broot=[^ ]*' | cut -d = -f 2 | cut -d "/" -f3`
+
 find /sys/block/ -maxdepth 1 -regex '.*[sv]d.*' -exec basename '{}' ';'| sort | while read -r disk ; do
   echo "Processing $disk"
+  if [ "$rootdisk" = "$disk" ]; then
+    echo "Ignoring the rootdisk $rootdisk"
+    continue
+  fi
   targetDir=$(sed "${mountPointLineNo}q;d" /mnt/mountPoints)
   if [ -z "$targetDir" ]
     then


### PR DESCRIPTION
Handle launching container as VM
Disable GC for now until all issues are fixed.
For now external-boot-image container is downloaded from docker.io/zededapramodh/external-boot-scratch-container:2.0

If USB install is done that image is downloaded for you. 

Please run following command in eve Kube container manually.
ctr  -a /run/containerd-user/containerd.sock -n k8s.io  image pull docker.io/zededapramodh/external-boot-scratch-container:2.0
