### PR TITLE
VMI remove cni0 interface, fix a bug in advertise appkubenetstatus

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:d812fa9bfd099088c656e031fd21c0e1a42ce872 as build
+#FROM lfedge/eve-alpine:d812fa9bfd099088c656e031fd21c0e1a42ce872 as build
+FROM lfedge/eve-alpine:2ce6af13cbeb90e4ba3fda8903172ecc064580bb as build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep cni-plugins \

--- a/pkg/pillar/cmd/zedkube/aitoapiserver.go
+++ b/pkg/pillar/cmd/zedkube/aitoapiserver.go
@@ -88,10 +88,11 @@ func publishAppKubeNetStatus(ctx *zedkubeContext, ebStatus *EveClusterInstStatus
 	log.Noticef("publishAppKubeNetStatus: for eve-bridge %v, ni-status %v, nistatus uuid %v, appnet len %d",
 		ebStatus, status, status.UUIDandVersion.UUID, len(ctx.appKubeNetStatus))
 	for ainame, akStatus := range ctx.appKubeNetStatus {
-		log.Noticef("publishAppKubeNetStatus:(%s) akStatus size %d", ainame, len(akStatus.ULNetworkStatusList))
+		log.Noticef("publishAppKubeNetStatus:(%s) akStatus size %d, podname %s", ainame, len(akStatus.ULNetworkStatusList), ebStatus.PodName)
 		for i, ulstatus := range akStatus.ULNetworkStatusList {
 			log.Noticef("publishAppKubeNetStatus:(%d) ulcfg network %v", i, ulstatus.Network)
-			if ulstatus.Network.String() == status.UUIDandVersion.UUID.String() {
+			if ulstatus.Network.String() == status.UUIDandVersion.UUID.String() &&
+				strings.Contains(ebStatus.PodName, ainame) {
 				var err error
 				ulx := ulstatus
 				ulx.Vif = ebStatus.VifName

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -241,24 +241,22 @@ func (ctx kubevirtContext) CreateVMIConfig(domainName string, config types.Domai
 	}
 
 	// Set Network
-	intfs := make([]v1.Interface, len(kubeNADs)+1)
-	nads := make([]v1.Network, len(kubeNADs)+1)
-	intfs[0] = v1.Interface{
-		Name:                   "default",
-		InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-	}
-	nads[0] = *v1.DefaultPodNetwork()
+
+	// XXX for now, skip the default network interface for VMI, it seems some type of VM
+	// it's 2nd interface came up without IP address unless manually run dhclient on it
+	intfs := make([]v1.Interface, len(kubeNADs))
+	nads := make([]v1.Network, len(kubeNADs))
 
 	if len(kubeNADs) > 0 {
 		for i, nad := range kubeNADs {
 			intfname := "net" + strconv.Itoa(i+1)
-			intfs[i+1] = v1.Interface{
+			intfs[i] = v1.Interface{
 				Name:                   intfname,
 				MacAddress:             nad.Mac,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 			}
 
-			nads[i+1] = v1.Network{
+			nads[i] = v1.Network{
 				Name: intfname,
 				NetworkSource: v1.NetworkSource{
 					Multus: &v1.MultusNetwork{


### PR DESCRIPTION
- it seems some type of VM not assigned with ip address in ztest due to 2nd intf
   remove the cni0 default network interface when creating VMI
- fix a bug when multiple Apps using the same network-instance, it may get 
   the wrong App for the network
- updated Kube alpine hash in dockerfile