### PR TITLE
Fix and issue of Kubevirt v1.1.0 virt-handler pod crashing

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 K3S_VERSION=v1.26.3+k3s1
-KUBEVIRT_VERSION=v0.59.0
+KUBEVIRT_VERSION=v1.1.0
 LONGHORN_VERSION=v1.4.2
 CDI_VERSION=v1.56.0
 Node_IP=""
@@ -135,6 +135,7 @@ setup_prereqs () {
         wait_for_default_route
         check_network_connection
         wait_for_device_uuid
+        chmod o+rw /dev/null
 }
 
 apply_longhorn_disk_config() {

--- a/pkg/kube/kubevirt-operator.yaml
+++ b/pkg/kube/kubevirt-operator.yaml
@@ -139,6 +139,95 @@ spec:
                             type: object
                         type: object
                     type: object
+                  architectureConfiguration:
+                    properties:
+                      amd64:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
+                      arm64:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
+                      defaultArchitecture:
+                        type: string
+                      ppc64le:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
+                    type: object
+                  autoCPULimitNamespaceLabelSelector:
+                    description: When set, AutoCPULimitNamespaceLabelSelector will
+                      set a CPU limit on virt-launcher for VMIs running inside namespaces
+                      that match the label selector. The CPU limit will equal the
+                      number of requested vCPUs. This setting does not apply to VMIs
+                      with dedicated CPUs.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   controllerConfiguration:
                     description: ReloadableComponentConfiguration holds all generic
                       k8s configuration options which can be reloaded by components
@@ -317,7 +406,87 @@ spec:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image
                     type: string
+                  ksmConfiguration:
+                    description: KSMConfiguration holds the information regarding
+                      the enabling the KSM in the nodes (if available).
+                    properties:
+                      nodeLabelSelector:
+                        description: NodeLabelSelector is a selector that filters
+                          in which nodes the KSM will be enabled. Empty NodeLabelSelector
+                          will enable ksm for every node.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                    type: object
+                  liveUpdateConfiguration:
+                    description: LiveUpdateConfiguration holds defaults for live update
+                      features
+                    properties:
+                      maxCpuSockets:
+                        description: MaxCpuSockets holds the maximum amount of sockets
+                          that can be hotplugged
+                        format: int32
+                        type: integer
+                      maxGuest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: MaxGuest defines the maximum amount memory that
+                          can be allocated to the guest using hotplug.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      maxHotplugRatio:
+                        description: 'MaxHotplugRatio is the ratio used to define
+                          the max amount of a hotplug resource that can be made available
+                          to a VM when the specific Max* setting is not defined (MaxCpuSockets,
+                          MaxGuest) Example: VM is configured with 512Mi of guest
+                          memory, if MaxGuest is not defined and MaxHotplugRatio is
+                          2 then MaxGuest = 1Gi defaults to 4'
+                        format: int32
+                        type: integer
+                    type: object
                   machineType:
+                    description: Deprecated. Use architectureConfiguration instead.
                     type: string
                   mediatedDevicesConfiguration:
                     description: MediatedDevicesConfiguration holds information about
@@ -337,7 +506,7 @@ spec:
                       nodeMediatedDeviceTypes:
                         items:
                           description: NodeMediatedDeviceTypesConfig holds information
-                            about MDEV types to be defined in a specifc node that
+                            about MDEV types to be defined in a specific node that
                             matches the NodeSelector field.
                           properties:
                             mediatedDeviceTypes:
@@ -392,8 +561,8 @@ spec:
                         - type: integer
                         - type: string
                         description: BandwidthPerMigration limits the amount of network
-                          bandwith live migrations are allowed to use. The value is
-                          in quantity per second. Defaults to 0 (no limit)
+                          bandwidth live migrations are allowed to use. The value
+                          is in quantity per second. Defaults to 0 (no limit)
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       completionTimeoutPerGiB:
@@ -408,6 +577,16 @@ spec:
                         description: When set to true, DisableTLS will disable the
                           additional layer of live migration encryption provided by
                           KubeVirt. This is usually a bad idea. Defaults to false
+                        type: boolean
+                      matchSELinuxLevelOnMigration:
+                        description: By default, the SELinux level of target virt-launcher
+                          pods is forced to the level of the source virt-launcher.
+                          When set to true, MatchSELinuxLevelOnMigration lets the
+                          CRI auto-assign a random level to the target. That will
+                          ensure the target virt-launcher doesn't share categories
+                          with another pod on the node. However, migrations will fail
+                          when using RWX volumes that don't automatically deal with
+                          SELinux levels.
                         type: boolean
                       network:
                         description: Network is the name of the CNI network to use
@@ -450,6 +629,23 @@ spec:
                   network:
                     description: NetworkConfiguration holds network options
                     properties:
+                      binding:
+                        additionalProperties:
+                          properties:
+                            networkAttachmentDefinition:
+                              description: 'NetworkAttachmentDefinition references
+                                to a NetworkAttachmentDefinition CR object. Format:
+                                <name>, <namespace>/<name>. If namespace is not specified,
+                                VMI namespace is assumed. version: 1alphav1'
+                              type: string
+                            sidecarImage:
+                              description: 'SidecarImage references a container image
+                                that runs in the virt-launcher pod. The sidecar handles
+                                (libvirt) domain configuration and optional services.
+                                version: 1alphav1'
+                              type: string
+                          type: object
+                        type: object
                       defaultNetworkInterface:
                         type: string
                       permitBridgeInterfaceOnPodNetwork:
@@ -500,13 +696,40 @@ spec:
                             resourceName:
                               description: The name of the resource that is representing
                                 the device. Exposed by a device plugin and requested
-                                by VMs. Typically of the form vendor.com/product_nameThe
-                                name of the resource that is representing the device.
-                                Exposed by a device plugin and requested by VMs. Typically
-                                of the form vendor.com/product_name
+                                by VMs. Typically of the form vendor.com/product_name
                               type: string
                           required:
                           - pciVendorSelector
+                          - resourceName
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      usb:
+                        items:
+                          properties:
+                            externalResourceProvider:
+                              description: If true, KubeVirt will leave the allocation
+                                and monitoring to an external device plugin
+                              type: boolean
+                            resourceName:
+                              description: 'Identifies the list of USB host devices.
+                                e.g: kubevirt.io/storage, kubevirt.io/bootable-usb,
+                                etc'
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  product:
+                                    type: string
+                                  vendor:
+                                    type: string
+                                required:
+                                - product
+                                - vendor
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
                           - resourceName
                           type: object
                         type: array
@@ -561,6 +784,29 @@ spec:
                           description: ResourceRequirements describes the compute
                             resource requirements.
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -624,6 +870,27 @@ spec:
                     type: object
                   virtualMachineInstancesPerNode:
                     type: integer
+                  virtualMachineOptions:
+                    description: VirtualMachineOptions holds the cluster level information
+                      regarding the virtual machine.
+                    properties:
+                      disableFreePageReporting:
+                        description: DisableFreePageReporting disable the free page
+                          reporting of memory balloon device https://libvirt.org/formatdomain.html#memory-balloon-device.
+                          This will have effect only if AutoattachMemBalloon is not
+                          false and the vmi is not requesting any high performance
+                          feature (dedicatedCPU/realtime/hugePages), in which free
+                          page reporting is always disabled.
+                        type: object
+                      disableSerialConsoleLog:
+                        description: DisableSerialConsoleLog disables logging the
+                          auto-attached default serial console. If not set, serial
+                          console logs will be written to a file and then streamed
+                          from a container named 'guest-console-log'. The value can
+                          be individually overridden for each VM, not relevant if
+                          AutoattachSerialConsole is disabled.
+                        type: object
+                    type: object
                   vmStateStorageClass:
                     description: VMStateStorageClass is the name of the storage class
                       to use for the PVCs created to preserve VM state, like TPM.
@@ -1050,9 +1317,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -1112,7 +1376,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -1221,9 +1485,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -1280,7 +1542,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -1391,9 +1653,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -1453,7 +1712,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -1562,9 +1821,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -1621,7 +1878,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -2086,9 +2343,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -2148,7 +2402,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -2257,9 +2511,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -2316,7 +2568,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -2427,9 +2679,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -2489,7 +2738,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -2598,9 +2847,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -2657,7 +2904,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -2771,6 +3018,8 @@ spec:
                   - type
                   type: object
                 type: array
+              defaultArchitecture:
+                type: string
               generations:
                 items:
                   description: GenerationStatus keeps track of the generation for
@@ -2839,7 +3088,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -2849,6 +3098,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    deprecated: true
+    deprecationWarning: kubevirt.io/v1alpha3 is now deprecated and will be removed
+      in a future release.
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -2955,6 +3207,95 @@ spec:
                             type: object
                         type: object
                     type: object
+                  architectureConfiguration:
+                    properties:
+                      amd64:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
+                      arm64:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
+                      defaultArchitecture:
+                        type: string
+                      ppc64le:
+                        properties:
+                          emulatedMachines:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          machineType:
+                            type: string
+                          ovmfPath:
+                            type: string
+                        type: object
+                    type: object
+                  autoCPULimitNamespaceLabelSelector:
+                    description: When set, AutoCPULimitNamespaceLabelSelector will
+                      set a CPU limit on virt-launcher for VMIs running inside namespaces
+                      that match the label selector. The CPU limit will equal the
+                      number of requested vCPUs. This setting does not apply to VMIs
+                      with dedicated CPUs.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   controllerConfiguration:
                     description: ReloadableComponentConfiguration holds all generic
                       k8s configuration options which can be reloaded by components
@@ -3133,7 +3474,87 @@ spec:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image
                     type: string
+                  ksmConfiguration:
+                    description: KSMConfiguration holds the information regarding
+                      the enabling the KSM in the nodes (if available).
+                    properties:
+                      nodeLabelSelector:
+                        description: NodeLabelSelector is a selector that filters
+                          in which nodes the KSM will be enabled. Empty NodeLabelSelector
+                          will enable ksm for every node.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                    type: object
+                  liveUpdateConfiguration:
+                    description: LiveUpdateConfiguration holds defaults for live update
+                      features
+                    properties:
+                      maxCpuSockets:
+                        description: MaxCpuSockets holds the maximum amount of sockets
+                          that can be hotplugged
+                        format: int32
+                        type: integer
+                      maxGuest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: MaxGuest defines the maximum amount memory that
+                          can be allocated to the guest using hotplug.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      maxHotplugRatio:
+                        description: 'MaxHotplugRatio is the ratio used to define
+                          the max amount of a hotplug resource that can be made available
+                          to a VM when the specific Max* setting is not defined (MaxCpuSockets,
+                          MaxGuest) Example: VM is configured with 512Mi of guest
+                          memory, if MaxGuest is not defined and MaxHotplugRatio is
+                          2 then MaxGuest = 1Gi defaults to 4'
+                        format: int32
+                        type: integer
+                    type: object
                   machineType:
+                    description: Deprecated. Use architectureConfiguration instead.
                     type: string
                   mediatedDevicesConfiguration:
                     description: MediatedDevicesConfiguration holds information about
@@ -3153,7 +3574,7 @@ spec:
                       nodeMediatedDeviceTypes:
                         items:
                           description: NodeMediatedDeviceTypesConfig holds information
-                            about MDEV types to be defined in a specifc node that
+                            about MDEV types to be defined in a specific node that
                             matches the NodeSelector field.
                           properties:
                             mediatedDeviceTypes:
@@ -3208,8 +3629,8 @@ spec:
                         - type: integer
                         - type: string
                         description: BandwidthPerMigration limits the amount of network
-                          bandwith live migrations are allowed to use. The value is
-                          in quantity per second. Defaults to 0 (no limit)
+                          bandwidth live migrations are allowed to use. The value
+                          is in quantity per second. Defaults to 0 (no limit)
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       completionTimeoutPerGiB:
@@ -3224,6 +3645,16 @@ spec:
                         description: When set to true, DisableTLS will disable the
                           additional layer of live migration encryption provided by
                           KubeVirt. This is usually a bad idea. Defaults to false
+                        type: boolean
+                      matchSELinuxLevelOnMigration:
+                        description: By default, the SELinux level of target virt-launcher
+                          pods is forced to the level of the source virt-launcher.
+                          When set to true, MatchSELinuxLevelOnMigration lets the
+                          CRI auto-assign a random level to the target. That will
+                          ensure the target virt-launcher doesn't share categories
+                          with another pod on the node. However, migrations will fail
+                          when using RWX volumes that don't automatically deal with
+                          SELinux levels.
                         type: boolean
                       network:
                         description: Network is the name of the CNI network to use
@@ -3266,6 +3697,23 @@ spec:
                   network:
                     description: NetworkConfiguration holds network options
                     properties:
+                      binding:
+                        additionalProperties:
+                          properties:
+                            networkAttachmentDefinition:
+                              description: 'NetworkAttachmentDefinition references
+                                to a NetworkAttachmentDefinition CR object. Format:
+                                <name>, <namespace>/<name>. If namespace is not specified,
+                                VMI namespace is assumed. version: 1alphav1'
+                              type: string
+                            sidecarImage:
+                              description: 'SidecarImage references a container image
+                                that runs in the virt-launcher pod. The sidecar handles
+                                (libvirt) domain configuration and optional services.
+                                version: 1alphav1'
+                              type: string
+                          type: object
+                        type: object
                       defaultNetworkInterface:
                         type: string
                       permitBridgeInterfaceOnPodNetwork:
@@ -3316,13 +3764,40 @@ spec:
                             resourceName:
                               description: The name of the resource that is representing
                                 the device. Exposed by a device plugin and requested
-                                by VMs. Typically of the form vendor.com/product_nameThe
-                                name of the resource that is representing the device.
-                                Exposed by a device plugin and requested by VMs. Typically
-                                of the form vendor.com/product_name
+                                by VMs. Typically of the form vendor.com/product_name
                               type: string
                           required:
                           - pciVendorSelector
+                          - resourceName
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      usb:
+                        items:
+                          properties:
+                            externalResourceProvider:
+                              description: If true, KubeVirt will leave the allocation
+                                and monitoring to an external device plugin
+                              type: boolean
+                            resourceName:
+                              description: 'Identifies the list of USB host devices.
+                                e.g: kubevirt.io/storage, kubevirt.io/bootable-usb,
+                                etc'
+                              type: string
+                            selectors:
+                              items:
+                                properties:
+                                  product:
+                                    type: string
+                                  vendor:
+                                    type: string
+                                required:
+                                - product
+                                - vendor
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
                           - resourceName
                           type: object
                         type: array
@@ -3377,6 +3852,29 @@ spec:
                           description: ResourceRequirements describes the compute
                             resource requirements.
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -3440,6 +3938,27 @@ spec:
                     type: object
                   virtualMachineInstancesPerNode:
                     type: integer
+                  virtualMachineOptions:
+                    description: VirtualMachineOptions holds the cluster level information
+                      regarding the virtual machine.
+                    properties:
+                      disableFreePageReporting:
+                        description: DisableFreePageReporting disable the free page
+                          reporting of memory balloon device https://libvirt.org/formatdomain.html#memory-balloon-device.
+                          This will have effect only if AutoattachMemBalloon is not
+                          false and the vmi is not requesting any high performance
+                          feature (dedicatedCPU/realtime/hugePages), in which free
+                          page reporting is always disabled.
+                        type: object
+                      disableSerialConsoleLog:
+                        description: DisableSerialConsoleLog disables logging the
+                          auto-attached default serial console. If not set, serial
+                          console logs will be written to a file and then streamed
+                          from a container named 'guest-console-log'. The value can
+                          be individually overridden for each VM, not relevant if
+                          AutoattachSerialConsole is disabled.
+                        type: object
+                    type: object
                   vmStateStorageClass:
                     description: VMStateStorageClass is the name of the storage class
                       to use for the PVCs created to preserve VM state, like TPM.
@@ -3866,9 +4385,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -3928,7 +4444,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4037,9 +4553,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -4096,7 +4610,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4207,9 +4721,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -4269,7 +4780,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4378,9 +4889,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -4437,7 +4946,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4902,9 +5411,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -4964,7 +5470,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -5073,9 +5579,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -5132,7 +5636,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -5243,9 +5747,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -5305,7 +5806,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -5414,9 +5915,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -5473,7 +5972,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -5587,6 +6086,8 @@ spec:
                   - type
                   type: object
                 type: array
+              defaultArchitecture:
+                type: string
               generations:
                 items:
                   description: GenerationStatus keeps track of the generation for
@@ -5655,7 +6156,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 
@@ -5754,6 +6255,18 @@ rules:
   - routes/custom-host
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - update
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -5950,22 +6463,6 @@ rules:
   - watch
   - patch
 - apiGroups:
-  - flavor.kubevirt.io
-  resources:
-  - virtualmachineflavors
-  - virtualmachineclusterflavors
-  - virtualmachinepreferences
-  - virtualmachineclusterpreferences
-  verbs:
-  - get
-  - delete
-  - create
-  - update
-  - patch
-  - list
-  - watch
-  - deletecollection
-- apiGroups:
   - ""
   resources:
   - pods
@@ -6060,6 +6557,14 @@ rules:
   resources:
   - datasources
   - datavolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
   verbs:
   - get
   - list
@@ -6246,7 +6751,8 @@ rules:
   - virtualmachineinstances/freeze
   - virtualmachineinstances/unfreeze
   - virtualmachineinstances/softreboot
-  - virtualmachineinstances/addinterface
+  - virtualmachineinstances/sev/setupsession
+  - virtualmachineinstances/sev/injectlaunchsecret
   verbs:
   - update
 - apiGroups:
@@ -6261,8 +6767,6 @@ rules:
   - network-attachment-definitions
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -6343,6 +6847,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes
@@ -6366,6 +6877,18 @@ rules:
   - list
   - get
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - update
+  - create
+  - patch
 - apiGroups:
   - kubevirt.io
   resources:
@@ -6473,6 +6996,8 @@ rules:
   - virtualmachineinstances/guestosinfo
   - virtualmachineinstances/filesystemlist
   - virtualmachineinstances/userlist
+  - virtualmachineinstances/sev/fetchcertchain
+  - virtualmachineinstances/sev/querylaunchmeasurement
   verbs:
   - get
 - apiGroups:
@@ -6485,7 +7010,8 @@ rules:
   - virtualmachineinstances/freeze
   - virtualmachineinstances/unfreeze
   - virtualmachineinstances/softreboot
-  - virtualmachineinstances/addinterface
+  - virtualmachineinstances/sev/setupsession
+  - virtualmachineinstances/sev/injectlaunchsecret
   verbs:
   - update
 - apiGroups:
@@ -6505,7 +7031,6 @@ rules:
   - virtualmachines/removevolume
   - virtualmachines/migrate
   - virtualmachines/memorydump
-  - virtualmachines/addinterface
   verbs:
   - update
 - apiGroups:
@@ -6619,6 +7144,8 @@ rules:
   - virtualmachineinstances/guestosinfo
   - virtualmachineinstances/filesystemlist
   - virtualmachineinstances/userlist
+  - virtualmachineinstances/sev/fetchcertchain
+  - virtualmachineinstances/sev/querylaunchmeasurement
   verbs:
   - get
 - apiGroups:
@@ -6631,7 +7158,8 @@ rules:
   - virtualmachineinstances/freeze
   - virtualmachineinstances/unfreeze
   - virtualmachineinstances/softreboot
-  - virtualmachineinstances/addinterface
+  - virtualmachineinstances/sev/setupsession
+  - virtualmachineinstances/sev/injectlaunchsecret
   verbs:
   - update
 - apiGroups:
@@ -6651,7 +7179,6 @@ rules:
   - virtualmachines/removevolume
   - virtualmachines/migrate
   - virtualmachines/memorydump
-  - virtualmachines/addinterface
   verbs:
   - update
 - apiGroups:
@@ -6763,6 +7290,8 @@ rules:
   - virtualmachineinstances/guestosinfo
   - virtualmachineinstances/filesystemlist
   - virtualmachineinstances/userlist
+  - virtualmachineinstances/sev/fetchcertchain
+  - virtualmachineinstances/sev/querylaunchmeasurement
   verbs:
   - get
 - apiGroups:
@@ -6832,6 +7361,15 @@ rules:
   - migrations.kubevirt.io
   resources:
   - migrationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - instancetype.kubevirt.io
+  resources:
+  - virtualmachineclusterinstancetypes
+  - virtualmachineclusterpreferences
   verbs:
   - get
   - list
@@ -6909,30 +7447,30 @@ spec:
         - virt-operator
         env:
         - name: VIRT_OPERATOR_IMAGE
-          value: index.docker.io/naimingshen/virt-operator@sha256:2eb976700078429ba25df55dcd923c1b7764eb4c60762094c71b4796ffb45f9c
+          value: index.docker.io/naimingshen/virt-operator@sha256:c6649283b793913d64c19cd31e6b2f17c1f9cc8c8846f18352b4b5b2e90f04be
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
         - name: VIRT_API_SHASUM
-          value: sha256:f4ee0fc58a229f4febd4b5e9fe2a0821aa6cff048aea9532a00019c43af44ffb
+          value: sha256:d033bf2425c8be556e774467bcce5fff431a4d889c688ba9a92bef2a33ab540e
         - name: VIRT_CONTROLLER_SHASUM
-          value: sha256:80df9ada98043e2f304059c90c27649d2fec95c77d42a3e5b87b23c276264d2d
+          value: sha256:fd9d8a5f21f8c4d64f9c4e66b5aa3f8fb7a3c10d969649dad8b2bc8245de2f86
         - name: VIRT_HANDLER_SHASUM
-          value: sha256:2d88e7359886842d6c84c6e8f1dc8849e26f48ffe1b6ccccae2f13835ee37ae4
+          value: sha256:7637ce4eb6ddfbd98a570fa06f4f5dc55b8567ba3361d9bd9ac165ab3c0804e5
         - name: VIRT_LAUNCHER_SHASUM
-          value: sha256:f8a53eeaaee43a899385c56ca36970e293712323f8e4fab8e4e71c93f6c27993
+          value: sha256:fd6307b0170a13ddceb73506a966b323fbbd2524549da40b0cf0de610c12ee9a
         - name: VIRT_EXPORTPROXY_SHASUM
-          value: sha256:3724cb4f953f4c96d40ae524a7330ce0cd418ebec919f0cee78f6574f8ea3a37
+          value: sha256:1769c4be68d9d5b34eb5cd59ec39f05acc20bacc28fc84fb572065c51c2046e1
         - name: VIRT_EXPORTSERVER_SHASUM
-          value: sha256:369caa036568330294bcd9b99e4a865cf878c96d2f95cbd14a976c46479349d7
+          value: sha256:1c520f67ab02bae9c412817ef147eaba94869a6fb45ca06def04c1538dc26f43
         - name: GS_SHASUM
-          value: sha256:d6e13c109eb4dab5adebc6eda16bb075440346d99238bafb2d0c07d0dfaab0ab
+          value: sha256:49fc603723d479ba145c001d1feea3fc803a66e031bfa9947b3b56f534855a71
         - name: PR_HELPER_SHASUM
-          value: sha256:080d7d4763918091d59d059a09a9d140eb6cf24a2e57f1357130c6e102df24ab
+          value: sha256:24368e553dc7bc52089a734196e7634e306cab33dc49c205c93ccb3162e5c0b9
         - name: KUBEVIRT_VERSION
-          value: latest2
-        image: index.docker.io/naimingshen/virt-operator@sha256:2eb976700078429ba25df55dcd923c1b7764eb4c60762094c71b4796ffb45f9c
+          value: latest
+        image: index.docker.io/naimingshen/virt-operator@sha256:c6649283b793913d64c19cd31e6b2f17c1f9cc8c8846f18352b4b5b2e90f04be
         imagePullPolicy: IfNotPresent
         name: virt-operator
         ports:

--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -133,14 +133,25 @@ func publishAppNetworkConfig(ctx *zedmanagerContext,
 	}
 	key := config.Key()
 	log.Functionf("publishAppNetworkConfig(%s)", key)
+	found := false
 	if akStatus != nil {
 		pub := ctx.pubAppNetworkConfig
+		items := pub.GetAll()
+		for _, item := range items {
+			c := item.(types.AppNetworkConfig)
+			if c.UUIDandVersion.UUID.String() == config.UUIDandVersion.UUID.String() {
+				found = true
+				break
+			}
+		}
 		pub.Publish(key, *config)
 	} else {
 		ctx.saveAppNetConfig[key] = *config
 		log.Functionf("publishAppNetworkConfig(%s), save locally, wait for AppKubeNetStatus", key)
 	}
-	ctx.anStatusChan <- key
+	if !found {
+		ctx.anStatusChan <- key
+	}
 }
 
 func unpublishAppNetworkConfig(ctx *zedmanagerContext, uuidStr string) {

--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -185,8 +185,9 @@ func (z *zedrouter) doActivateAppNetwork(config types.AppNetworkConfig,
 			// XXX temp hack until zedrouter changes
 			// to avoid after restart, getting NI Reconciler: App a2d92010-5dbc-40f2-a5d1-baeeeae8be4c is already connected
 			z.addAppNetworkError(status, "doActivateAppNetwork", err)
+		} else {
+			return
 		}
-		return
 	}
 	z.log.Functionf("Activated application network %s (%s), status %+v", status.UUIDandVersion.UUID,
 		status.DisplayName, status)


### PR DESCRIPTION
- need to chmod on /dev/null, which virt-handler checks
- a temp fix for zedmanager watchdog in some test case