### PR TITLE
move kube logs to /persist/newlog/kube directory

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -11,10 +11,11 @@ CDI_VERSION=v1.58.0
 Node_IP=""
 MAX_K3S_RESTARTS=10
 RESTART_COUNT=0
-K3S_LOG_DIR="/var/lib/"
+K3S_LOG_DIR="/persist/newlog/kube"
 loglimitSize=$((5*1024*1024))
 
-INSTALL_LOG=/var/lib/install.log
+# install log in K3S_LOG_DIR k3s-install.log
+INSTALL_LOG="${K3S_LOG_DIR}/k3s-install.log"
 
 logmsg() {
    local MSG
@@ -152,6 +153,7 @@ setup_prereqs () {
         modprobe iscsi_tcp
         #Needed for iscsi tools
         mkdir -p /run/lock
+        mkdir -p "$K3S_LOG_DIR"
         /usr/sbin/iscsid start
         mount --make-rshared /
         setup_cgroup
@@ -525,9 +527,10 @@ else
           check_overwrite_nsmounter
         fi
 fi
-        check_log_file_size "rancher/k3s/k3s.log"
-        check_log_file_size "rancher/k3s/multus.log"
-        check_log_file_size "install.log"
+        check_log_file_size "k3s.log"
+        check_log_file_size "multus.log"
+        check_log_file_size "k3s-install.log"
+        check_log_file_size "eve-bridge.log"
         check_and_run_vnc
         wait_for_item "wait"
         sleep 30

--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -3,7 +3,7 @@
 
 write-kubeconfig-mode: "0644"
 cluster-init: true
-log: "/var/lib/rancher/k3s/k3s.log"
+log: "/persist/newlog/kube/k3s.log"
 # Use longhorn storage
 disable: local-storage
 etcd-arg:

--- a/pkg/kube/eve-bridge/eve-bridge.go
+++ b/pkg/kube/eve-bridge/eve-bridge.go
@@ -35,7 +35,7 @@ const (
 )
 
 const (
-	logfileDir    = "/tmp/eve-bridge/"
+	logfileDir    = "/persist/newlog/kube/"
 	logfile       = logfileDir + "eve-bridge.log"
 	logMaxSize    = 100 // 100 Mbytes in size
 	logMaxBackups = 3   // old log files to retain

--- a/pkg/kube/multus-daemonset.yaml
+++ b/pkg/kube/multus-daemonset.yaml
@@ -124,7 +124,7 @@ data:
       "capabilities": {
         "portMappings": true
       },
-      "logFile": "/var/lib/rancher/k3s/multus.log",
+      "logFile": "/persist/newlog/kube/multus.log",
       "logLevel": "debug",
       "binDir": "/var/lib/cni/bin",
       "kubeconfig": "/var/lib/rancher/k3s/agent/etc/cni/net.d/multus.d/multus.kubeconfig",


### PR DESCRIPTION
- move install.log, k3s.log, multus.log and eve-bridge.log into /persist/newlog/kube