### PR TITLE
Disable network policies to avoid conflicts between EVE and kube-router

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -12,3 +12,4 @@ etcd-arg:
   - "quota-backend-bytes=8589934592"
 etcd-expose-metrics: true
 container-runtime-endpoint: "/run/containerd-user/containerd.sock"
+disable-network-policy: true


### PR DESCRIPTION
Disable [netpol controller from kube-router](https://github.com/cloudnativelabs/kube-router/tree/v2.0/pkg/controllers/netpol).