### PR TITLE
limit app name to kubernetes to max of 32 bytes, reanable traefik/svclb

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -6,8 +6,6 @@ cluster-init: true
 log: "/persist/newlog/kube/k3s.log"
 # Use longhorn storage
 disable: local-storage
-disable: traefik
-disable: servicelb
 etcd-arg:
   - "heartbeat-interval=8000"
   - "election-timeout=40000"

--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -22,6 +22,25 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - volumes
+      - volumes/status
+      - replicas
+      - replicas/status
+      - nodes
+      - nodes/status
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/pillar/base/kubevirt.go
+++ b/pkg/pillar/base/kubevirt.go
@@ -5,12 +5,15 @@ package base
 
 import (
 	"os"
+	"regexp"
 	"strings"
 )
 
 const (
 	// EveVirtTypeFile contains the virtualization type, ie kvm, xen or kubevirt
 	EveVirtTypeFile = "/run/eve-hv-type"
+	// Max length of the name in Kubernetes App plus app's UUID prefix
+	EveKubeAppMaxNameLen = 32
 )
 
 // IsHVTypeKube - return true if the EVE image is kube cluster type.
@@ -26,9 +29,19 @@ func IsHVTypeKube() bool {
 	return false
 }
 
-// ConvToKubeName - convert to lowercase and underscore to dash
+// ConvToKubeName - convert to lowercase and underscore to dash,
+// and truncate to 32 characters
 func ConvToKubeName(inName string) string {
-	lowercaseString := strings.ToLower(inName)
-	// Replace underscores with dashes for kubernetes
-	return strings.ReplaceAll(lowercaseString, "_", "-")
+	// Replace underscores with dashes for Kubernetes
+	processedString := strings.ReplaceAll(inName[:EveKubeAppMaxNameLen], "_", "-")
+
+	// Remove special characters using regular expressions
+	reg := regexp.MustCompile("[^a-zA-Z0-9-.]")
+	processedString = reg.ReplaceAllString(processedString, "")
+
+	// Reduce combinations like '-.-' or '.-.' to a single dash
+	processedString = regexp.MustCompile("[.-]+").ReplaceAllString(processedString, "-")
+
+	lowercaseString := strings.ToLower(processedString)
+	return lowercaseString
 }

--- a/pkg/pillar/cmd/zedrouter/cni.go
+++ b/pkg/pillar/cmd/zedrouter/cni.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/kube/cnirpc"
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/nireconciler"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -326,7 +327,7 @@ func (z *zedrouter) getAppByPodName(
 	}
 	for _, item := range z.pubAppNetworkStatus.GetAll() {
 		appStatus := item.(types.AppNetworkStatus)
-		if strings.ToLower(appStatus.DisplayName) == appName &&
+		if base.ConvToKubeName(appStatus.DisplayName) == appName &&
 			strings.HasPrefix(appStatus.UUIDandVersion.UUID.String(), appUUIDPrefix) {
 			appConfig := z.lookupAppNetworkConfig(appStatus.Key())
 			if appConfig == nil {


### PR DESCRIPTION
- limit the app name to kubernetes w/ max of 32 characters (plus uuid prefix)
- reanable the k3s traefik and svclb, it seems to cause problems for PVCs if disabled
- allow storage class objects to be queried