### PR TITLE
Switch to sqlite db for single node setup.

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -2,12 +2,9 @@
 # k3s server config file.
 
 write-kubeconfig-mode: "0644"
-cluster-init: true
 log: "/persist/newlog/kube/k3s.log"
 # Use longhorn storage
 disable: local-storage
-disable: traefik
-disable: servicelb
 etcd-arg:
   - "heartbeat-interval=8000"
   - "election-timeout=40000"


### PR DESCRIPTION
TBD will need a method to switch between the
sqlite single node and etcd cluster variants.
Also includes polling waits for each component
to start before installing the next (kubevirt,longhorn,...)

This is motivated by the k3s crashes caused by poor etcd performance.
The sqlite backend performs better than etcd on systems with slower drives.