### PR TITLE
Port forward to lh 1.6 nsmounter

### DIFF
--- a/pkg/kube/nsmounter
+++ b/pkg/kube/nsmounter
@@ -1,13 +1,49 @@
 #!/bin/bash
-# No awk in longhorn-csi-plugin container at this time, thus the messy greps and cut
-mountPid=$$
-while [ $mountPid -ne 1 ]; do
-    grep Name /proc/$mountPid/status | grep -q -E 'dockerd|containerd|containerd-shim'
-    if [ $? != 0 ]; then
-        mountPid=$(grep PPid /proc/$mountPid/status | cut -d ':' -f 2 | xargs)
-        continue
+
+PROC_DIR="/proc"
+
+os_distro_talos="talos"
+os_distro_eve="eve"
+os_distro=""
+
+get_os_distro() {
+  local version_info=$(< $PROC_DIR/version)
+
+  [[ $version_info =~ $os_distro_talos ]] && os_distro=$os_distro_talos
+  [[ $version_info =~ $os_distro_eve ]] && os_distro=$os_distro_eve
+}
+
+target_pid=1
+
+get_pid() {
+  local process_name=$1
+  local pid
+  local status_file
+  local name
+
+  for dir in $PROC_DIR/*/; do
+    pid=$(basename "$dir")
+    status_file="$PROC_DIR/$pid/status"
+
+    if [ -f "$status_file" ]; then
+      while IFS= read -r line; do
+        if [[ $line == "Name:"* ]]; then
+          name="${line#*:}"
+          name="${name//[$'\t ']/}"  # Remove both spaces and tabs
+          break  # Exit the loop once the Name is found
+        fi
+      done < "$status_file"
     fi
-    break
-done
-echo "kube pid:$mountPid"
-nsenter -t $mountPid -m -n -u -- "$@"
+
+    if [ "$name" = "$process_name" ]; then
+      target_pid=$pid
+    fi
+  done
+}
+
+get_os_distro
+
+[[ $os_distro = $os_distro_talos ]] && get_pid "kubelet"
+[[ $os_distro = $os_distro_eve ]] && get_pid "containerd-shim"
+
+nsenter -t $target_pid -m -n -u -- "$@"


### PR DESCRIPTION
The longhorn project has updated the nsmounter
script to search for a pid but still needs fixes
for finding our correct ns.  This commit does
two items: move up to the nsmounter longhorn
has in the 1.6 dev branch and add changes needed
to correctly find the pid in eve.