### PR TITLE
add clusterrole to allow metrics of node/pod

### DIFF
--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -41,6 +41,14 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
- allow debug-users to do 'kubectl top [node | pod]' commands