### PR TITLE
Change pid name to cluster-init.sh

### DIFF
--- a/pkg/kube/nsmounter
+++ b/pkg/kube/nsmounter
@@ -44,6 +44,6 @@ get_pid() {
 get_os_distro
 
 [[ $os_distro = $os_distro_talos ]] && get_pid "kubelet"
-[[ $os_distro = $os_distro_eve ]] && get_pid "containerd-shim"
+[[ $os_distro = $os_distro_eve ]] && get_pid "cluster-init.sh"
 
 nsenter -t $target_pid -m -n -u -- "$@"


### PR DESCRIPTION
The containerd-shim name can lookup many k3s pod pids, this fixes that to consistently pick the correct pid.