### PR TITLE
Add a custom 1 replica storageclass

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /etc/containerd
 COPY kubevirt-features.yaml /etc
 COPY config-k3s.toml /etc/containerd/
 COPY longhorn-config.yaml /etc/
+COPY longhorn-1replica-storageclass.yaml /etc/
 COPY debuguser-role-binding.yaml /etc/
 COPY external-boot-image.tar /etc/
 RUN ls -l /etc/

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -547,6 +547,7 @@ if [ ! -f /var/lib/all_components_initialized ]; then
             #kubectl apply -f  https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml
             # Switch back to above once all the longhorn services use the updated go iscsi tools
             kubectl apply -f /etc/longhorn-config.yaml
+            kubectl apply -f /etc/longhorn-1replica-storageclass.yaml
             touch /var/lib/longhorn_initialized
           fi
           sleep 10

--- a/pkg/kube/longhorn-1replica-storageclass.yaml
+++ b/pkg/kube/longhorn-1replica-storageclass.yaml
@@ -1,0 +1,10 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-1replica
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -191,7 +191,7 @@ func NewPVCDefinition(pvcName string, size string, annotations, labels map[strin
 			Namespace:   types.VolumeCSINameSpace,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			StorageClassName: stringPtr(types.VolumeCSIClusterStorageClass),
+			StorageClassName: stringPtr(types.VolumeCSISingleNodeStorageClass),
 			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			VolumeMode:       &volumeModeBlock,
 			Resources: corev1.ResourceRequirements{

--- a/pkg/pillar/types/kube.go
+++ b/pkg/pillar/types/kube.go
@@ -13,6 +13,8 @@ const (
 	VolumeCSINameSpace = "eve-kube-app"
 	// CSI clustered storage class
 	VolumeCSIClusterStorageClass = "longhorn"
+	// CSI single node storage class
+	VolumeCSISingleNodeStorageClass = "longhorn-1replica"
 	// Default local storage class
 	VolumeCSILocalStorageClass = "local-path"
 )


### PR DESCRIPTION
This will allow longhorn volumes to be healthy
on these initial single node systems and
enable longhorn engine auto migration
during upgrade.