### PR TITLE
Add PCI reserve/release and also fix flooding of logs

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -815,7 +816,7 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 				}
 			}
 			fillMetrics(res, domainName, metricName, parsedValue)
-			logrus.Infof("GetDomsCPUMem: vmi %s, domainName %s, metric name %s, value %v", vmiName, domainName, metricName, parsedValue)
+			logrus.Debugf("GetDomsCPUMem: vmi %s, domainName %s, metric name %s, value %v", vmiName, domainName, metricName, parsedValue)
 		}
 	}
 
@@ -1388,4 +1389,89 @@ func addKernelBootContainer(spec *v1.VirtualMachineInstanceSpec, image, kernelAr
 	}
 
 	return spec
+}
+
+// PCIReserve reserves a PCI device for Kubevirt
+func (ctx kubevirtContext) PCIReserve(long string) error {
+	logrus.Infof("PCIReserve long addr is %s", long)
+
+	overrideFile := filepath.Join(sysfsPciDevices, long, "driver_override")
+	driverPath := filepath.Join(sysfsPciDevices, long, "driver")
+	unbindFile := filepath.Join(driverPath, "unbind")
+
+	//Check if already bound to vfio-pci
+	driverPathInfo, driverPathErr := os.Stat(driverPath)
+	vfioDriverPathInfo, vfioDriverPathErr := os.Stat(vfioDriverPath)
+	if driverPathErr == nil && vfioDriverPathErr == nil &&
+		os.SameFile(driverPathInfo, vfioDriverPathInfo) {
+		logrus.Infof("Driver for %s is already bound to vfio-pci, skipping unbind", long)
+		return nil
+	}
+
+	//map vfio-pci as the driver_override for the device
+	if err := os.WriteFile(overrideFile, []byte("vfio-pci"), 0644); err != nil {
+		return logError("driver_override failure for PCI device %s: %v",
+			long, err)
+	}
+
+	//Unbind the current driver, whatever it is, if there is one
+	if _, err := os.Stat(unbindFile); err == nil {
+		if err := os.WriteFile(unbindFile, []byte(long), 0644); err != nil {
+			return logError("unbind failure for PCI device %s: %v",
+				long, err)
+		}
+	}
+
+	if err := os.WriteFile(sysfsPciDriversProbe, []byte(long), 0644); err != nil {
+		return logError("drivers_probe failure for PCI device %s: %v",
+			long, err)
+	}
+
+	return nil
+}
+
+// PCIRelease releases the PCI device reservation
+func (ctx kubevirtContext) PCIRelease(long string) error {
+	logrus.Infof("PCIRelease long addr is %s", long)
+
+	overrideFile := filepath.Join(sysfsPciDevices, long, "driver_override")
+	unbindFile := filepath.Join(sysfsPciDevices, long, "driver/unbind")
+
+	//Write Empty string, to clear driver_override for the device
+	if err := os.WriteFile(overrideFile, []byte("\n"), 0644); err != nil {
+		logrus.Fatalf("driver_override failure for PCI device %s: %v",
+			long, err)
+	}
+
+	//Unbind vfio-pci, if unbind file is present
+	if _, err := os.Stat(unbindFile); err == nil {
+		if err := os.WriteFile(unbindFile, []byte(long), 0644); err != nil {
+			logrus.Fatalf("unbind failure for PCI device %s: %v",
+				long, err)
+		}
+	}
+
+	//Write PCI DDDD:BB:DD.FF to /sys/bus/pci/drivers_probe,
+	//as a best-effort to bring back original driver
+	if err := os.WriteFile(sysfsPciDriversProbe, []byte(long), 0644); err != nil {
+		logrus.Fatalf("drivers_probe failure for PCI device %s: %v",
+			long, err)
+	}
+
+	return nil
+}
+
+// PCISameController checks if two PCI controllers are the same
+func (ctx kubevirtContext) PCISameController(id1 string, id2 string) bool {
+	tag1, err := types.PCIGetIOMMUGroup(id1)
+	if err != nil {
+		return types.PCISameController(id1, id2)
+	}
+
+	tag2, err := types.PCIGetIOMMUGroup(id2)
+	if err != nil {
+		return types.PCISameController(id1, id2)
+	}
+
+	return tag1 == tag2
 }

--- a/pkg/pillar/types/zfs.go
+++ b/pkg/pillar/types/zfs.go
@@ -54,6 +54,12 @@ func (status VolumeStatus) UseZVolDisk(persistType PersistType) bool {
 	if status.ContentFormat == zconfig.Format_ISO {
 		return false
 	}
+
+	// A PVC volume is not a zvol though persist type is zfs
+	if status.ContentFormat == zconfig.Format_PVC {
+		return false
+	}
+
 	return persistType == PersistZFS
 }
 


### PR DESCRIPTION
Add PCIReserve and PCIRelease to kubevirt hypervisor, same as kvm.go

Tested NVMe disk passthrough works fine.