### PR TITLE
Fix chroot to call getpwuid only after chroot is called

### DIFF
--- a/pkg/external-boot-image/Dockerfile
+++ b/pkg/external-boot-image/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-xen-tools:c851ee132e313e380c8d716b21d2c2bc666a329e as initrd-build
+FROM lfedge/eve-xen-tools:18c6ea0119ec42fdc3e8eda57c1bfad6bf44b08f as initrd-build
 FROM docker.io/lfedge/eve-kernel:eve-kernel-amd64-v6.1.38-generic-d2da815271a2-gcc as  kernel-build
 
 FROM scratch

--- a/pkg/xen-tools/initrd/chroot2.c
+++ b/pkg/xen-tools/initrd/chroot2.c
@@ -29,18 +29,19 @@ static int child_func(void *args)
     struct clone_args *parsed_args = args;
     struct passwd *pws;
 
-    pws = getpwuid(parsed_args->uid);
-    if (pws == NULL)
-        err(-1, "getpwuid(%d) failed:", parsed_args->uid);
-
-    if (initgroups(pws->pw_name, parsed_args->gid) != 0)
-        err(-1, "initgroups(%s, %d) failed:", pws->pw_name, parsed_args->gid);
 
     if (chroot(parsed_args->chroot) != 0)
         err(-1, "chroot(%s) failed:", parsed_args->chroot);
 
     if (chdir(parsed_args->workdir) != 0)
         err(-1, "chdir(%s) failed:", parsed_args->workdir);
+
+    pws = getpwuid(parsed_args->uid);
+    if (pws == NULL)
+        err(-1, "getpwuid(%d) failed:", parsed_args->uid);
+
+    if (initgroups(pws->pw_name, parsed_args->gid) != 0)
+        err(-1, "initgroups(%s, %d) failed:", pws->pw_name, parsed_args->gid);
 
     if (mount("proc", "/proc", "proc", 0, NULL) != 0)
         err(-1, "mount(proc) failed:");


### PR DESCRIPTION
There is a regression in chroot2.c in base eve code. Due to that containers with non-root user id cannot start.
Fixed that. We need to check for getpwuid only after chroot is set.

After this fix grafana container starts