### PR TITLE
collect-info.sh: Add longhorn supportbundle zip

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -5,7 +5,7 @@
 #
 
 # Script version, don't forget to bump up once something is changed
-VERSION=13
+VERSION=14
 
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
@@ -303,6 +303,22 @@ collect_kube_info()
     fi
 }
 
+collect_longhorn_info()
+{
+    type=$(cat /run/eve-hv-type)
+    if [ "$type" != "kubevirt" ]; then
+        return
+    fi
+    echo "- Collecting Longhorn specific info"
+    {
+        echo "  - longhorn support bundle "
+        # Longhorn issue reports have seen hangs generating this data 
+        # when nodes are down, or due to longhorn bugs.  
+        # Give up after 5min, and allow remaining system data to be collected.  
+        timeout 300s eve exec kube /usr/bin/longhorn-generate-support-bundle.sh
+    } > "$DIR/longhorn-info" 2>&1
+}
+
 # Copy itself
 cp "${0}" "$DIR"
 
@@ -385,6 +401,7 @@ collect_zfs_info
 
 # Kube part
 collect_kube_info
+collect_longhorn_info
 
 # Make a tarball
 # --exclude='root-run/run'              /run/run/run/.. exclude symbolic link loop

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /etc/containerd
 COPY kubevirt-features.yaml /etc
 COPY config-k3s.toml /etc/containerd/
 COPY longhorn-config.yaml /etc/
+COPY longhorn-generate-support-bundle.sh /usr/bin/
 COPY debuguser-role-binding.yaml /etc/
 COPY external-boot-image.tar /etc/
 COPY iscsid.conf /etc/iscsi/

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+LOG_DIR=/persist/newlog/kube
+
+lhVersion=$(kubectl -n longhorn-system get configmap/longhorn-default-setting -o json | jq -r '.metadata.labels."app.kubernetes.io/version"')
+if [[ "$lhVersion" = *"v1.4"* ]]; then
+    echo "Unsupported longhorn version for support bundles.  Please USB install to get 1.5.3";
+    exit 0
+fi
+
+echo "Apply longhorn support bundle yaml at $(date)"
+
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: longhorn.io/v1beta2
+kind: SupportBundle
+metadata:
+  name: support-bundle-collect-info
+  namespace: longhorn-system
+spec:
+  description: collect-info
+  issueURL: ""
+  nodeID: ""
+EOF
+
+ready=0
+while [ $ready -ne 1 ]; do
+    state=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.state)
+    if [ "$state" = "ReadyForDownload" ]; then
+        ready=1
+        break
+    fi
+    sleep 10
+    progress=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.progress)
+    echo "support bundle progress percentage: $progress"
+done
+
+ip=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.managerIP)
+filename=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.filename)
+
+old_log_count=$(find "$LOG_DIR" -type f -name "longhornsupportbundle_*" | wc -l)
+if [ $old_log_count -gt 4 ]; then 
+    rm $(find "$LOG_DIR" -type f -name "longhornsupportbundle_*" | sort -n | head -n -4)
+fi
+
+curl http://${ip}:8080/bundle > ${LOG_DIR}/longhorn${filename}
+echo "longhorn support bundle downloaded to ${LOG_DIR}/longhorn${filename}"
+
+kubectl -n longhorn-system delete supportbundle.longhorn.io/support-bundle-collect-info


### PR DESCRIPTION
Run longhorn-generate-support-bundle.sh to generate a longhorn supportbundle zip containing complete logs from longhorn pods and kubernetes env.

On each execution it will delete all bundles older than the most recent 5 to be respectful of disk space.