### PR TITLE
Re-disable local-path

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -4,6 +4,7 @@
 write-kubeconfig-mode: "0644"
 log: "/persist/newlog/kube/k3s.log"
 # Use longhorn storage
+disable: local-storage
 etcd-arg:
   - "heartbeat-interval=8000"
   - "election-timeout=40000"


### PR DESCRIPTION
local-path storage uses the /var/lib etcd fs be default which isn't large enough for the scratch pvcs cdi-upload creates.

This should be a short-term fix until completing a PR to reconfigure local-path's root dir and improve cdi upload speed.