### PR TITLE
Changes for kubevirt VM ethernet passthrough

### DIFF
--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -15,6 +15,7 @@ rules:
   - apiGroups:
       - kubevirt.io
     resources:
+      - kubevirts
       - virtualmachines
       - virtualmachineinstances
       - virtualmachineinstancepresets

--- a/pkg/pillar/cmd/zedkube/aitoapiserver.go
+++ b/pkg/pillar/cmd/zedkube/aitoapiserver.go
@@ -25,6 +25,9 @@ import (
 
 func check_ioAdapter_ethernet(ctx *zedkubeContext, aiConfig *types.AppInstanceConfig) error {
 
+	if aiConfig.FixedResources.VirtualizationMode != types.KubeContainer {
+		return nil
+	}
 	ioAdapter := aiConfig.IoAdapterList
 	for _, io := range ioAdapter {
 		if io.Type == types.IoNetEth {
@@ -48,6 +51,9 @@ func check_ioAdapter_ethernet(ctx *zedkubeContext, aiConfig *types.AppInstanceCo
 
 func check_del_ioAdpater_ethernet(ctx *zedkubeContext, aiConfig *types.AppInstanceConfig) {
 
+	if aiConfig.FixedResources.VirtualizationMode != types.KubeContainer {
+		return
+	}
 	ioAdapter := aiConfig.IoAdapterList
 	for _, io := range ioAdapter {
 		if io.Type == types.IoNetEth {


### PR DESCRIPTION
- remove some checks for io passthrough, check if it is native container
- skip io register to kubevirt if the ethernet name is not in ioadapter
- no need to generate NAD for io passthrough if it's a VM