### PR TITLE
Kubevirt etcd-storage zvol encrypted with vault

### DIFF
--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -20,8 +20,10 @@ import (
 )
 
 const (
-	zfsKeyDir  = "/run/TmpVaultDir2"
-	zfsKeyFile = zfsKeyDir + "/protector.key"
+	zfsKeyDir                       = "/run/TmpVaultDir2"
+	zfsKeyFile                      = zfsKeyDir + "/protector.key"
+	vaultZvolPathWaitSeconds int64  = 20
+	vaultFsType              string = "ext4"
 )
 
 // ZFSHandler handles vault operations with ZFS
@@ -96,7 +98,7 @@ func (h *ZFSHandler) SetupDefaultVault() error {
 				return fmt.Errorf("error creating zfs non-tpm vault %s, error=%v",
 					types.SealedDataset, err)
 			}
-			if err := CreateZvolEtcd(h.log, types.EtcdZvol); err != nil {
+			if err := CreateZvolEtcd(h.log, types.EtcdZvol, "", false); err != nil {
 				return fmt.Errorf("error creating zfs etcd zvol %s, error=%v",
 					types.EtcdZvol, err)
 			}
@@ -141,6 +143,22 @@ func (h *ZFSHandler) unlockVault(vaultPath string) error {
 
 	// zfs mount
 	if base.IsHVTypeKube() {
+		// Some earlier builds did not have an encrypted etcd vol.
+		// Attempting to load-key on that config will cause entire vault setup to error out.
+		encrypted, err := isDatasetEncrypted(types.EtcdZvol)
+		if err != nil {
+			h.log.Errorf("Error checking dataset encryption enabled: %v", err)
+			return err
+		}
+		if encrypted {
+			// zfs load-key here separately for types.EtcdZvol because we don't mount it here, only in kube.
+			args := []string{"load-key", types.EtcdZvol}
+			if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
+				h.log.Errorf("Error loading key for etcd vol vault: %v, %s, %s",
+					err, stdOut, stdErr)
+				return err
+			}
+		}
 		if err := MountVaultZvol(h.log, vaultPath); err != nil {
 			h.log.Errorf("Error unlocking vault: %v", err)
 			return err
@@ -171,7 +189,7 @@ func (h *ZFSHandler) createVault(vaultPath string) error {
 			h.log.Errorf("Error creating zfs vault %s, error=%v", vaultPath, err)
 			return err
 		}
-		if err := CreateZvolEtcd(h.log, types.EtcdZvol); err != nil {
+		if err := CreateZvolEtcd(h.log, types.EtcdZvol, zfsKeyFile, true); err != nil {
 			return fmt.Errorf("error creating zfs etcd zvol %s, error=%v", types.EtcdZvol, err)
 		}
 	} else {
@@ -300,6 +318,22 @@ func (h *ZFSHandler) checkOperationalStatus(vaultPath string) error {
 	return nil
 }
 
+func isDatasetEncrypted(vaultPath string) (bool, error) {
+	dataset, err := libzfs.DatasetOpen(vaultPath)
+	if err != nil {
+		return false, err
+	}
+	defer dataset.Close()
+
+	encryption, err := dataset.GetProperty(libzfs.DatasetPropEncryption)
+	if err != nil {
+		return false, fmt.Errorf("DatasetExist(%s): Get property Encryption failed. %s",
+			vaultPath, err.Error())
+
+	}
+	return encryption.Value != "off", nil
+}
+
 // waitPath - Wait up to the requested number of seconds for path to exist or return error
 func waitPath(log *base.LogObject, path string, seconds int64) error {
 	begin_time := time.Now().Unix()
@@ -372,9 +406,6 @@ func enableFastCommits(log *base.LogObject, zvolDevPath string) error {
 	return nil
 }
 
-const vaultZvolPathWaitSeconds int64 = 20
-const vaultFsType string = "ext4"
-
 // CreateZvolVault Create and mount an empty vault dataset zvol
 func CreateZvolVault(log *base.LogObject, datasetName string, zfsKeyFile string, encrypted bool) error {
 	// Remaining space in the pool
@@ -391,7 +422,14 @@ func CreateZvolVault(log *base.LogObject, datasetName string, zfsKeyFile string,
 		return fmt.Errorf("Dataset %s available bytes read error: %v", parentDatasetName, err)
 	}
 
-	err = zfs.CreateVaultVolumeDataset(log, datasetName, zfsKeyFile, encrypted, sizeBytes)
+	if sizeBytes < zfs.ReserveEveStorageSizeGb {
+		//Bypass for dev/test VMs in eden
+		sizeBytes = sizeBytes - (zfs.VolBlockSize * 1024)
+	} else {
+		sizeBytes = sizeBytes - zfs.ReserveEveStorageSizeGb - (zfs.VolBlockSize * 1024)
+	}
+
+	err = zfs.CreateVaultVolumeDataset(log, datasetName, zfsKeyFile, encrypted, sizeBytes, "zstd", zfs.VolBlockSize)
 	if err != nil {
 		return fmt.Errorf("Vault zvol creation error; %v", err)
 	}
@@ -414,7 +452,7 @@ func CreateZvolVault(log *base.LogObject, datasetName string, zfsKeyFile string,
 }
 
 // CreateZvolEtcd Create and mount an empty vault dataset zvol
-func CreateZvolEtcd(log *base.LogObject, datasetName string) error {
+func CreateZvolEtcd(log *base.LogObject, datasetName string, zfsKeyFile string, encrypted bool) error {
 	// Remaining space in the pool
 	sizeBytes := uint64(0)
 	etcdSizeBytes := uint64(1024 * 1024 * 1024 * 1)
@@ -434,7 +472,7 @@ func CreateZvolEtcd(log *base.LogObject, datasetName string) error {
 		etcdSizeBytes = 1024 * 1024 * 1024 * 10
 	}
 
-	err = zfs.CreateVolumeDataset(log, datasetName, etcdSizeBytes, "off", uint64(4*1024))
+	err = zfs.CreateVaultVolumeDataset(log, datasetName, zfsKeyFile, encrypted, etcdSizeBytes, "off", uint64(4*1024))
 	if err != nil {
 		return fmt.Errorf("Etcd zvol creation error; %v", err)
 	}

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -105,15 +105,9 @@ func GetZvolPath(datasetName string) string {
 }
 
 // CreateVaultVolumeDataset Create an empty vault zvol
-func CreateVaultVolumeDataset(log *base.LogObject, datasetName string, zfsKeyFile string, encrypted bool, sizeBytes uint64) error {
+func CreateVaultVolumeDataset(log *base.LogObject, datasetName string, zfsKeyFile string, encrypted bool, sizeBytes uint64, compression string, blockSize uint64) error {
 	// Shave off reserved + Can't align up if we're already at max space.
-	if sizeBytes < ReserveEveStorageSizeGb {
-		//Bypass for dev/test VMs in eden
-		sizeBytes = sizeBytes - (VolBlockSize * 1024)
-	} else {
-		sizeBytes = sizeBytes - ReserveEveStorageSizeGb - (VolBlockSize * 1024)
-	}
-	alignedSize := alignUpToBlockSize(sizeBytes, VolBlockSize)
+	alignedSize := alignUpToBlockSize(sizeBytes, blockSize)
 	props := make(map[libzfs.Prop]libzfs.Property)
 
 	if encrypted {
@@ -127,11 +121,11 @@ func CreateVaultVolumeDataset(log *base.LogObject, datasetName string, zfsKeyFil
 	props[libzfs.DatasetPropVolsize] = libzfs.Property{
 		Value: strconv.FormatUint(alignedSize, 10)}
 	props[libzfs.DatasetPropVolblocksize] = libzfs.Property{
-		Value: strconv.FormatUint(VolBlockSize, 10)}
+		Value: strconv.FormatUint(blockSize, 10)}
 	props[libzfs.DatasetPropVolmode] = libzfs.Property{
 		Value: "dev"}
 	props[libzfs.DatasetPropCompression] = libzfs.Property{
-		Value: "zstd"}
+		Value: compression}
 
 	dataset, err := libzfs.DatasetCreate(datasetName, libzfs.DatasetTypeVolume, props)
 	if err != nil {

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -105,7 +105,7 @@ func GetZvolPath(datasetName string) string {
 }
 
 // CreateVaultVolumeDataset Create an empty vault zvol
-func CreateVaultVolumeDataset(log *base.LogObject, datasetName string, zfsKeyFile string, encrypted bool, sizeBytes uint64, compression string, blockSize uint64) error {
+func CreateVaultVolumeDataset(log *base.LogObject, datasetName string, zfsKeyFile string, encrypted bool, sizeBytes uint64, compressionType string, blockSize uint64) error {
 	// Shave off reserved + Can't align up if we're already at max space.
 	alignedSize := alignUpToBlockSize(sizeBytes, blockSize)
 	props := make(map[libzfs.Prop]libzfs.Property)
@@ -125,7 +125,7 @@ func CreateVaultVolumeDataset(log *base.LogObject, datasetName string, zfsKeyFil
 	props[libzfs.DatasetPropVolmode] = libzfs.Property{
 		Value: "dev"}
 	props[libzfs.DatasetPropCompression] = libzfs.Property{
-		Value: compression}
+		Value: compressionType}
 
 	dataset, err := libzfs.DatasetCreate(datasetName, libzfs.DatasetTypeVolume, props)
 	if err != nil {


### PR DESCRIPTION
Also cleanup and organize constants.

Previous implementation left etcd-storage open, this PR causes new installs to encrypt etcd-storage identically to vault.