### PR TITLE
Keep calling apply_multus_cni until yaml applies cleanly.

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -502,12 +502,10 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         fi
 
         if [ ! -f /var/lib/multus_initialized ]; then
-          if are_all_pods_ready; then
-            logmsg "Installing multus cni"
-            apply_multus_cni
-            # launch CNI dhcp service
-            /opt/cni/bin/dhcp daemon &
-          fi
+          logmsg "Installing multus cni"
+          apply_multus_cni
+          # launch CNI dhcp service
+          /opt/cni/bin/dhcp daemon &
           sleep 10
           continue
         fi

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -177,6 +177,8 @@ apply_multus_cni() {
   logmsg "done applying multus"
   ln -s /var/lib/cni/bin/multus /var/lib/rancher/k3s/data/current/bin/multus
   # need to only do this once
+  # launch CNI dhcp service
+  /opt/cni/bin/dhcp daemon &
   touch /var/lib/multus_initialized
   return 0
 }
@@ -504,8 +506,6 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         if [ ! -f /var/lib/multus_initialized ]; then
           logmsg "Installing multus cni"
           apply_multus_cni
-          # launch CNI dhcp service
-          /opt/cni/bin/dhcp daemon &
           sleep 10
           continue
         fi
@@ -595,8 +595,10 @@ else
                 if [ ! -f /var/lib/multus_initialized ]; then
                   apply_multus_cni
                 fi
-                # launch CNI dhcp service
-                /opt/cni/bin/dhcp daemon &
+                pgrep -f "/opt/cni/bin/dhcp daemon" > /dev/null 2>&1
+                if [ $? -eq 1 ]; then
+                  /opt/cni/bin/dhcp daemon &
+                fi
 
                 # setup debug user credential, role and binding
                 if [ ! -f /var/lib/debuguser-initialized ]; then


### PR DESCRIPTION
multus-daemonset.yaml doesn't always apply successfully on the first try. Resolves a semi-rare install-time hang.