### PR TITLE
Cleanup code in volumemgr

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 
 	zconfig "github.com/lf-edge/eve-api/go/config"
-	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
 )
@@ -20,10 +19,7 @@ var volumeHash []byte
 
 // volumeKey returns the key of the VM and OCI volumes
 func volumeKey(volumeID string, generationCounter, localGenCounter int64) string {
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", volumeID, generationCounter+localGenCounter)
-	}
+
 	return fmt.Sprintf("%s#%d", volumeID, generationCounter+localGenCounter)
 }
 

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -26,13 +26,9 @@ func MaybeAddVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 
 	var key string
 
-	if base.IsHVTypeKube() {
-		key = fmt.Sprintf("%s-pvc-%d", volumeID.String(),
-			generationCounter+localGenerationCounter)
-	} else {
-		key = fmt.Sprintf("%s#%d", volumeID.String(),
-			generationCounter+localGenerationCounter)
-	}
+	key = fmt.Sprintf("%s#%d", volumeID.String(),
+		generationCounter+localGenerationCounter)
+
 	log.Functionf("MaybeAddVolumeRefConfig for %s", key)
 	m := lookupVolumeRefConfig(ctx, key)
 	if m != nil {
@@ -68,13 +64,8 @@ func MaybeRemoveVolumeRefConfig(ctx *zedmanagerContext, appInstID uuid.UUID,
 
 	var key string
 
-	if base.IsHVTypeKube() {
-		key = fmt.Sprintf("%s-pvc-%d", volumeID.String(),
-			generationCounter+localGenerationCounter)
-	} else {
-		key = fmt.Sprintf("%s#%d", volumeID.String(),
-			generationCounter+localGenerationCounter)
-	}
+	key = fmt.Sprintf("%s#%d", volumeID.String(),
+		generationCounter+localGenerationCounter)
 
 	log.Functionf("MaybeRemoveVolumeRefConfig for %s", key)
 	m := lookupVolumeRefConfig(ctx, key)

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -318,6 +318,12 @@ func (ctx kubevirtContext) CreateVMIConfig(domainName string, config types.Domai
 					},
 				}
 			} else {
+
+				pvcName, err := ds.GetPVCNameFromVolumeKey()
+				if err != nil {
+					return logError("Failed to fetch PVC Name from volumekey %v", ds.VolumeKey)
+				}
+
 				disks[i] = v1.Disk{
 					Name: diskName,
 					DiskDevice: v1.DiskDevice{
@@ -331,7 +337,7 @@ func (ctx kubevirtContext) CreateVMIConfig(domainName string, config types.Domai
 					VolumeSource: v1.VolumeSource{
 						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-								ClaimName: ds.VolumeKey,
+								ClaimName: pvcName,
 							},
 						},
 					},

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -455,6 +455,24 @@ func (metric DomainMetric) Key() string {
 	return metric.UUIDandVersion.UUID.String()
 }
 
+func (status DiskStatus) GetPVCNameFromVolumeKey() (string, error) {
+	volumeIDAndGeneration := status.VolumeKey
+	generation := strings.Split(volumeIDAndGeneration, "#")
+	volUUID, err := uuid.FromString(generation[0])
+	if err != nil {
+		return "", fmt.Errorf("failed to parse volUUID: %s", err)
+	}
+
+	generationCounter, err := strconv.ParseInt(generation[1], 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse GenerationCounter: %s", err)
+	}
+
+	pvcName := fmt.Sprintf("%s-pvc-%d", volUUID, generationCounter)
+
+	return pvcName, nil
+}
+
 // LogCreate :
 func (metric DomainMetric) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.DomainMetricLogType, "",

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -33,11 +33,7 @@ type VolumeConfig struct {
 
 // Key is volume UUID which will be unique
 func (config VolumeConfig) Key() string {
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", config.VolumeID.String(),
-			config.GenerationCounter+config.LocalGenerationCounter)
-	}
+
 	return fmt.Sprintf("%s#%d", config.VolumeID.String(),
 		config.GenerationCounter+config.LocalGenerationCounter)
 }
@@ -149,11 +145,6 @@ type VolumeStatus struct {
 // Key is volume UUID which will be unique
 func (status VolumeStatus) Key() string {
 
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", status.VolumeID.String(),
-			status.GenerationCounter+status.LocalGenerationCounter)
-	}
 	return fmt.Sprintf("%s#%d", status.VolumeID.String(),
 		status.GenerationCounter+status.LocalGenerationCounter)
 }
@@ -176,6 +167,14 @@ func (status VolumeStatus) PathName() string {
 	return fmt.Sprintf("%s/%s#%d.%s", baseDir, status.VolumeID.String(),
 		status.GenerationCounter+status.LocalGenerationCounter,
 		strings.ToLower(status.ContentFormat.String()))
+}
+
+// PVCName returns the volume name for kubernetes(longhorn)
+func (status VolumeStatus) GetPVCName() string {
+
+	return fmt.Sprintf("%s-pvc-%d", status.VolumeID.String(),
+		status.GenerationCounter+status.LocalGenerationCounter)
+
 }
 
 // LogCreate :
@@ -331,22 +330,13 @@ type VolumeRefConfig struct {
 
 // Key : VolumeRefConfig unique key
 func (config VolumeRefConfig) Key() string {
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", config.VolumeID.String(),
-			config.GenerationCounter+config.LocalGenerationCounter)
-	}
+
 	return fmt.Sprintf("%s#%d", config.VolumeID.String(),
 		config.GenerationCounter+config.LocalGenerationCounter)
 }
 
 // VolumeKey : Unique key of volume referenced in VolumeRefConfig
 func (config VolumeRefConfig) VolumeKey() string {
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", config.VolumeID.String(),
-			config.GenerationCounter+config.LocalGenerationCounter)
-	}
 	return fmt.Sprintf("%s#%d", config.VolumeID.String(),
 		config.GenerationCounter+config.LocalGenerationCounter)
 }
@@ -427,22 +417,14 @@ type VolumeRefStatus struct {
 
 // Key : VolumeRefStatus unique key
 func (status VolumeRefStatus) Key() string {
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", status.VolumeID.String(),
-			status.GenerationCounter+status.LocalGenerationCounter)
-	}
+
 	return fmt.Sprintf("%s#%d", status.VolumeID.String(),
 		status.GenerationCounter+status.LocalGenerationCounter)
 }
 
 // VolumeKey : Unique key of volume referenced in VolumeRefStatus
 func (status VolumeRefStatus) VolumeKey() string {
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", status.VolumeID.String(),
-			status.GenerationCounter+status.LocalGenerationCounter)
-	}
+
 	return fmt.Sprintf("%s#%d", status.VolumeID.String(),
 		status.GenerationCounter+status.LocalGenerationCounter)
 }
@@ -550,11 +532,7 @@ type VolumeCreatePending struct {
 
 // Key : VolumeCreatePending unique key
 func (status VolumeCreatePending) Key() string {
-	// PVC names should not include # so lets choose -pvc-
-	if base.IsHVTypeKube() {
-		return fmt.Sprintf("%s-pvc-%d", status.VolumeID.String(),
-			status.GenerationCounter+status.LocalGenerationCounter)
-	}
+
 	return fmt.Sprintf("%s#%d", status.VolumeID.String(),
 		status.GenerationCounter+status.LocalGenerationCounter)
 }


### PR DESCRIPTION
These changes are for the review comments in https://github.com/lf-edge/eve/pull/3768
We do not need to set VolumeKey() and Key() for PVC. Just generate PVC name using  Volume UUID and generation counter.

Ran ztest suites ring0, applifecyclemultipapps.suite and they passed.
