### PR TITLE
ZFS Vault Cleanup and eve_install_kubevirt_etcd_sizeGB boot option

### DIFF
--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -133,7 +133,7 @@ in grub.cfg with graphical GRUB menu to get the device to boot again.
     12. `eve_install_skip_zfs_checks` - install zfs by skipping minimum requirement checks.
     13. `eve_install_zfs_with_raid_level` - Sets raid level for zfs storage. Valid values are none,raid1,raid5,raid6. Default value is none. This option also applied for the first boot of a live image to prepare zfs persist pool instead of ext4.
     14. `eve_install_kubevirt_reserve_for_eve_sizeGB` - Amount of space in GB to reserve for eve services in kubevirt based images (This is highly experimental and not supported config, also its an optional parameter and defaults to 20GB if not set)
-    15. `eve_install_kubevirt_etcd_sizeGB` - Size in GB of the etcd-storage zvol.
+    15. `eve_install_kubevirt_etcd_sizeGB` - Size in GB of the etcd-storage zvol.  Defaults to 10GB.
 3. General kernel parameters may be adjusted with `set_global dom0_extra_args "$dom0_extra_args OPTION1=VAL1 OPTION2 "`.
    They will be added to kernel cmdline.
 

--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -133,6 +133,7 @@ in grub.cfg with graphical GRUB menu to get the device to boot again.
     12. `eve_install_skip_zfs_checks` - install zfs by skipping minimum requirement checks.
     13. `eve_install_zfs_with_raid_level` - Sets raid level for zfs storage. Valid values are none,raid1,raid5,raid6. Default value is none. This option also applied for the first boot of a live image to prepare zfs persist pool instead of ext4.
     14. `eve_install_kubevirt_reserve_for_eve_sizeGB` - Amount of space in GB to reserve for eve services in kubevirt based images (This is highly experimental and not supported config, also its an optional parameter and defaults to 20GB if not set)
+    15. `eve_install_kubevirt_etcd_sizeGB` - Size in GB of the etcd-storage zvol.
 3. General kernel parameters may be adjusted with `set_global dom0_extra_args "$dom0_extra_args OPTION1=VAL1 OPTION2 "`.
    They will be added to kernel cmdline.
 

--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -132,8 +132,7 @@ in grub.cfg with graphical GRUB menu to get the device to boot again.
     11. `eve_install_skip_rootfs` - do not install rootfs partition onto device. May be selected from graphical GRUB menu.
     12. `eve_install_skip_zfs_checks` - install zfs by skipping minimum requirement checks.
     13. `eve_install_zfs_with_raid_level` - Sets raid level for zfs storage. Valid values are none,raid1,raid5,raid6. Default value is none. This option also applied for the first boot of a live image to prepare zfs persist pool instead of ext4.
-    14. `eve_install_kubevirt_reserve_for_eve_sizeGB` - Amount of space in GB to reserve for eve services in kubevirt based images (This is highly experimental and not supported config, also its an optional parameter and defaults to 20GB if not set)
-    15. `eve_install_kubevirt_etcd_sizeGB` - Size in GB of the etcd-storage zvol.  Defaults to 10GB.
+    14. `eve_install_kubevirt_etcd_sizeGB` - Size in GB of the etcd-storage zvol.  Defaults to 10GB.
 3. General kernel parameters may be adjusted with `set_global dom0_extra_args "$dom0_extra_args OPTION1=VAL1 OPTION2 "`.
    They will be added to kernel cmdline.
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -23,6 +23,7 @@
 #   eve_install_skip_zfs_checks
 #   eve_install_zfs_with_raid_level
 #   eve_install_kubevirt_reserve_for_eve_sizeGB
+#   eve_install_kubevirt_etcd_sizeGB
 #
 BAIL_FINAL_CMD=${BAIL_FINAL_CMD:-"exit 1"}
 [ -n "$DEBUG" ] && set -x
@@ -140,7 +141,7 @@ collect_black_box() {
    pillar_run tpmmgr saveTpmInfo "$1"/tpminfo.txt
 }
 
-# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX INSTALL_CLUSTERED_STORAGE RESERVE_EVE_STORAGE_SIZEGB
+# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX INSTALL_CLUSTERED_STORAGE
 prepare_mounts_and_zfs_pool() {
   logmsg "Preparing ZFS pool and mounts"
   [ -e /root/sys ] || mkdir /root/sys && mount -t sysfs sysfs /root/sys
@@ -151,12 +152,13 @@ prepare_mounts_and_zfs_pool() {
   chroot /root zfs create -o refreservation="$(chroot /root zfs get -o value -Hp available persist | awk '{ print ($1/1024/1024)/5 }')"m persist/reserved
   chroot /root zfs set mountpoint="/persist" persist
   chroot /root zfs set primarycache=metadata persist
-  if [ "$2" == false ]; then
+  # we need this mount to propagate persist from /root/persist after call to zfs command in changed root
+  [ -e /persist ] || mkdir /persist && mount --rbind --make-rslave /root/persist /persist
+
+  if [ "$2" = false ]; then
     # kubevirt persist/vault is an ext4 zvol
     chroot /root zfs create -o mountpoint="/persist/containerd/io.containerd.snapshotter.v1.zfs" persist/snapshots
   fi
-  # we need this mount to propagate persist from /root/persist after call to zfs command in changed root
-  [ -e /persist ] || mkdir /persist && mount --rbind --make-rslave /root/persist /persist
 }
 
 zfs_umount() {
@@ -297,15 +299,6 @@ eve_flavor=$(cat /root/etc/eve-hv-type)
 if [ "$eve_flavor" = "kubevirt" ]; then
    INSTALL_CLUSTERED_STORAGE=true
    INSTALL_ZFS=true
-   RESERVE_EVE_STORAGE_SIZEGB=$(</proc/cmdline tr ' ' '\012' | sed -ne '/^eve_install_kubevirt_reserve_for_eve_sizeGB=/s#^.*=##p')
-
-   #If not set, default it to 20GB
-   # NOTE reserving 20GB for eve services is an experimental change and could be modified in future after analysing data.
-   if [ -z "$RESERVE_EVE_STORAGE_SIZEGB" ]; then
-      RESERVE_EVE_STORAGE_SIZEGB=20
-   fi
-
-   logmsg "Kubevirt image installing ZFS and EVE reserved storage sizeGB $RESERVE_EVE_STORAGE_SIZEGB"
 fi
 
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -299,6 +299,7 @@ eve_flavor=$(cat /root/etc/eve-hv-type)
 if [ "$eve_flavor" = "kubevirt" ]; then
    INSTALL_CLUSTERED_STORAGE=true
    INSTALL_ZFS=true
+   logmsg "Kubevirt image installing ZFS and EVE reserved storage sizeGB"
 fi
 
 

--- a/pkg/mkimage-raw-efi/install
+++ b/pkg/mkimage-raw-efi/install
@@ -22,7 +22,6 @@
 #   eve_install_skip_rootfs
 #   eve_install_skip_zfs_checks
 #   eve_install_zfs_with_raid_level
-#   eve_install_kubevirt_reserve_for_eve_sizeGB
 #   eve_install_kubevirt_etcd_sizeGB
 #
 BAIL_FINAL_CMD=${BAIL_FINAL_CMD:-"exit 1"}

--- a/pkg/pillar/base/kubevirt.go
+++ b/pkg/pillar/base/kubevirt.go
@@ -22,6 +22,14 @@ const (
 	KubeAppNameUUIDPrefixLen = 5
 	// VMIPodNamePrefix : prefix added to name of every pod created to run VM.
 	VMIPodNamePrefix = "virt-launcher-"
+	// InstallOptionReserveEveStorageSizeGB grub option at install time.  Size to leave unallocated on kubevirt installs for expanding Etcd or vault later.
+	InstallOptionReserveEveStorageSizeGB = "eve_install_kubevirt_reserve_for_eve_sizeGB"
+	// DefaultReserveEveStorageSizeGB default for InstallOptionReserveEveStorageSizeGB
+	DefaultReserveEveStorageSizeGB = 20
+	// InstallOptionEtcdSizeGB grub option at install time.  Size of etcd volume in GB.
+	InstallOptionEtcdSizeGB = "eve_install_kubevirt_etcd_sizeGB"
+	// DefaultEtcdSizeGB default for InstallOptionEtcdSizeGB
+	DefaultEtcdSizeGB = 10
 )
 
 // IsHVTypeKube - return true if the EVE image is kube cluster type.

--- a/pkg/pillar/base/kubevirt.go
+++ b/pkg/pillar/base/kubevirt.go
@@ -22,14 +22,10 @@ const (
 	KubeAppNameUUIDPrefixLen = 5
 	// VMIPodNamePrefix : prefix added to name of every pod created to run VM.
 	VMIPodNamePrefix = "virt-launcher-"
-	// InstallOptionReserveEveStorageSizeGB grub option at install time.  Size to leave unallocated on kubevirt installs for expanding Etcd or vault later.
-	InstallOptionReserveEveStorageSizeGB = "eve_install_kubevirt_reserve_for_eve_sizeGB"
-	// DefaultReserveEveStorageSizeGB default for InstallOptionReserveEveStorageSizeGB
-	DefaultReserveEveStorageSizeGB = 20
 	// InstallOptionEtcdSizeGB grub option at install time.  Size of etcd volume in GB.
 	InstallOptionEtcdSizeGB = "eve_install_kubevirt_etcd_sizeGB"
 	// DefaultEtcdSizeGB default for InstallOptionEtcdSizeGB
-	DefaultEtcdSizeGB = 10
+	DefaultEtcdSizeGB uint32 = 10
 )
 
 // IsHVTypeKube - return true if the EVE image is kube cluster type.

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +25,11 @@ const (
 	zfsKeyFile                      = zfsKeyDir + "/protector.key"
 	vaultZvolPathWaitSeconds int64  = 20
 	vaultFsType              string = "ext4"
+)
+
+var (
+	reserveEveStorageSizeGB uint32 = base.DefaultReserveEveStorageSizeGB
+	etcdSizeGb              uint32 = base.DefaultEtcdSizeGB
 )
 
 // ZFSHandler handles vault operations with ZFS
@@ -58,6 +64,9 @@ func (h *ZFSHandler) SetupDeprecatedVaults() error {
 // SetHandlerOptions adjust handler options
 func (h *ZFSHandler) SetHandlerOptions(options HandlerOptions) {
 	h.options = options
+	if err := parseInstallSettings(); err != nil {
+		h.log.Errorf("Using defaults, parseInstallSettings failed: %v", err)
+	}
 }
 
 // GetVaultStatuses returns statuses of vault(s)
@@ -94,13 +103,13 @@ func (h *ZFSHandler) SetupDefaultVault() error {
 			if zfs.DatasetExist(h.log, types.SealedDataset) {
 				return MountVaultZvol(h.log, types.SealedDataset)
 			}
-			if err := CreateZvolVault(h.log, types.SealedDataset, "", false); err != nil {
-				return fmt.Errorf("error creating zfs non-tpm vault %s, error=%v",
-					types.SealedDataset, err)
-			}
 			if err := CreateZvolEtcd(h.log, types.EtcdZvol, "", false); err != nil {
 				return fmt.Errorf("error creating zfs etcd zvol %s, error=%v",
 					types.EtcdZvol, err)
+			}
+			if err := CreateZvolVault(h.log, types.SealedDataset, "", false); err != nil {
+				return fmt.Errorf("error creating zfs non-tpm vault %s, error=%v",
+					types.SealedDataset, err)
 			}
 			return nil
 		}
@@ -185,12 +194,12 @@ func (h *ZFSHandler) createVault(vaultPath string) error {
 	defer unstage()
 
 	if base.IsHVTypeKube() {
+		if err := CreateZvolEtcd(h.log, types.EtcdZvol, zfsKeyFile, true); err != nil {
+			return fmt.Errorf("error creating zfs etcd zvol %s, error=%v", types.EtcdZvol, err)
+		}
 		if err := CreateZvolVault(h.log, vaultPath, zfsKeyFile, true); err != nil {
 			h.log.Errorf("Error creating zfs vault %s, error=%v", vaultPath, err)
 			return err
-		}
-		if err := CreateZvolEtcd(h.log, types.EtcdZvol, zfsKeyFile, true); err != nil {
-			return fmt.Errorf("error creating zfs etcd zvol %s, error=%v", types.EtcdZvol, err)
 		}
 	} else {
 		if err := zfs.CreateVaultDataset(vaultPath, zfsKeyFile); err != nil {
@@ -336,7 +345,7 @@ func isDatasetEncrypted(vaultPath string) (bool, error) {
 
 // waitPath - Wait up to the requested number of seconds for path to exist or return error
 func waitPath(log *base.LogObject, path string, seconds int64) error {
-	begin_time := time.Now().Unix()
+	beginTime := time.Now().Unix()
 	for {
 		_, err := os.Stat(path)
 		if err != nil {
@@ -347,7 +356,7 @@ func waitPath(log *base.LogObject, path string, seconds int64) error {
 		} else {
 			return nil
 		}
-		if (time.Now().Unix() - begin_time) > seconds {
+		if (time.Now().Unix() - beginTime) > seconds {
 			break
 		}
 	}
@@ -422,12 +431,10 @@ func CreateZvolVault(log *base.LogObject, datasetName string, zfsKeyFile string,
 		return fmt.Errorf("Dataset %s available bytes read error: %v", parentDatasetName, err)
 	}
 
-	if sizeBytes < zfs.ReserveEveStorageSizeGb {
-		//Bypass for dev/test VMs in eden
-		sizeBytes = sizeBytes - (zfs.VolBlockSize * 1024)
-	} else {
-		sizeBytes = sizeBytes - zfs.ReserveEveStorageSizeGb - (zfs.VolBlockSize * 1024)
+	if sizeBytes <= (uint64(reserveEveStorageSizeGB) * 1024 * 1024 * 1024) {
+		return fmt.Errorf("Remaining space not large enough for vault and reserve: %v bytes", sizeBytes)
 	}
+	sizeBytes = sizeBytes - (uint64(reserveEveStorageSizeGB) * 1024 * 1024 * 1024)
 
 	err = zfs.CreateVaultVolumeDataset(log, datasetName, zfsKeyFile, encrypted, sizeBytes, "zstd", zfs.VolBlockSize)
 	if err != nil {
@@ -453,28 +460,11 @@ func CreateZvolVault(log *base.LogObject, datasetName string, zfsKeyFile string,
 
 // CreateZvolEtcd Create and mount an empty vault dataset zvol
 func CreateZvolEtcd(log *base.LogObject, datasetName string, zfsKeyFile string, encrypted bool) error {
-	// Remaining space in the pool
-	sizeBytes := uint64(0)
-	etcdSizeBytes := uint64(1024 * 1024 * 1024 * 1)
+	etcdSizeBytes := uint64(1024 * 1024 * 1024 * uint64(etcdSizeGb))
 
-	parentDatasetName := datasetName
-	if strings.Contains(parentDatasetName, "/") {
-		datasetParts := strings.Split(parentDatasetName, "/")
-		parentDatasetName = datasetParts[0]
-	}
-
-	sizeBytes, err := zfs.GetDatasetAvailableBytes(parentDatasetName)
+	err := zfs.CreateVaultVolumeDataset(log, datasetName, zfsKeyFile, encrypted, etcdSizeBytes, "off", uint64(4*1024))
 	if err != nil {
-		return fmt.Errorf("Dataset %s available bytes read error: %v", parentDatasetName, err)
-	}
-
-	if sizeBytes > (1024 * 1024 * 1024 * 10) {
-		etcdSizeBytes = 1024 * 1024 * 1024 * 10
-	}
-
-	err = zfs.CreateVaultVolumeDataset(log, datasetName, zfsKeyFile, encrypted, etcdSizeBytes, "off", uint64(4*1024))
-	if err != nil {
-		return fmt.Errorf("Etcd zvol creation error; %v", err)
+		return fmt.Errorf("Etcd zvol creation error: %v", err)
 	}
 
 	devPath := zfs.GetZvolPath(datasetName)
@@ -490,6 +480,35 @@ func CreateZvolEtcd(log *base.LogObject, datasetName string, zfsKeyFile string, 
 
 	if err = enableFastCommits(log, devPath); err != nil {
 		return fmt.Errorf("fast_commits not enabled on etcd vol: %v", err)
+	}
+	return nil
+}
+
+func parseInstallSettings() error {
+	data, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return err
+	}
+	bootArgs := strings.Fields(string(data))
+	for _, arg := range bootArgs {
+		if strings.HasPrefix(arg, base.InstallOptionReserveEveStorageSizeGB) {
+			argSplitted := strings.Split(arg, "=")
+			if len(argSplitted) == 2 {
+				valGB, err := strconv.Atoi(argSplitted[1])
+				if err == nil {
+					reserveEveStorageSizeGB = uint32(valGB)
+				}
+			}
+		}
+		if strings.HasPrefix(arg, base.InstallOptionEtcdSizeGB) {
+			argSplitted := strings.Split(arg, "=")
+			if len(argSplitted) == 2 {
+				valGB, err := strconv.Atoi(argSplitted[1])
+				if err == nil {
+					etcdSizeGb = uint32(valGB)
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -21,10 +21,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// VolBlockSize is the default dataset block size
 const VolBlockSize = uint64(16 * 1024)
-
-// taken from mkimage-raw-efi/install kubevirt RESERVE_EVE_STORAGE_SIZEGB
-const ReserveEveStorageSizeGb = uint64(20 * 1024 * 1024 * 1024)
 
 // CreateDatasets - creates all the non-existing parent datasets.
 // Datasets created in this manner are automatically mounted


### PR DESCRIPTION
Addition of new grub boot option 'eve_install_kubevirt_etcd_sizeGB' which specifies the size of the etcd zvol on kubevirt images. Cleanup of RESERVE_EVE_STORAGE_SIZEGB which is not used until first boot. Move kubevirt specific eve_install option constants to kubevirt.go. Parse both eve_install_kubevirt_reserve_for_eve_sizeGB and eve_install_kubevirt_etcd_sizeGB in vault handler_zfs.go before creating the zvols.
A few yetus errors were fixed in the process.