### PR TITLE
Collect /var/log/pods contents in kube

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -5,7 +5,7 @@
 #
 
 # Script version, don't forget to bump up once something is changed
-VERSION=14
+VERSION=15
 
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
@@ -299,6 +299,10 @@ collect_kube_info()
            echo "============"
            eve exec kube kubectl top pod -A --sum
            echo "============"
+           echo "/usr/bin/k3s-pod-logs.sh"
+           echo "============"
+           eve exec kube /usr/bin/k3s-pod-logs.sh
+           echo "============"
         } > "$DIR/kube-info"
     fi
 }
@@ -312,9 +316,9 @@ collect_longhorn_info()
     echo "- Collecting Longhorn specific info"
     {
         echo "  - longhorn support bundle "
-        # Longhorn issue reports have seen hangs generating this data 
-        # when nodes are down, or due to longhorn bugs.  
-        # Give up after 5min, and allow remaining system data to be collected.  
+        # Longhorn issue reports have seen hangs generating this data
+        # when nodes are down, or due to longhorn bugs.
+        # Give up after 5min, and allow remaining system data to be collected.
         timeout 300s eve exec kube /usr/bin/longhorn-generate-support-bundle.sh
     } > "$DIR/longhorn-info" 2>&1
 }

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -27,6 +27,7 @@ COPY kubevirt-features.yaml /etc
 COPY kubevirt-operator.yaml /etc
 COPY config-k3s.toml /etc/containerd/
 COPY longhorn-generate-support-bundle.sh /usr/bin/
+COPY k3s-pod-logs.sh /usr/bin/
 COPY debuguser-role-binding.yaml /etc/
 COPY external-boot-image.tar /etc/
 COPY iscsid.conf /etc/iscsi/

--- a/pkg/kube/k3s-pod-logs.sh
+++ b/pkg/kube/k3s-pod-logs.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+rm -f /persist/newlog/kube/k3s-pod-logs-*.tar.gz
+OUT_FILE=/persist/newlog/kube/k3s-pod-logs-$(date +'%Y%m%d-%H%M%S' -u).tar.gz
+tar cfz "$OUT_FILE" -C /var/log/pods/ .
+echo "Created: $OUT_FILE"


### PR DESCRIPTION
collect-info.sh will collect a tar of k3s pod logs from kube.
Also a few yetus trailing spaces removed from collect-info.sh.

This is intended to resolve missing cdi logs in debugging.