### PR TITLE
can not cache the kubeconfig in zedkube for cluster mode

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -436,6 +436,7 @@ done
 ln -s /persist/status       "$DIR/persist-status"
 ln -s /persist/log          "$DIR/persist-log"
 ln -s /persist/newlog       "$DIR/persist-newlog"
+[ -d /persist/kubelog ] && ln -s /persist/kubelog "$DIR/persist-kubelog"
 ln -s /persist/netdump      "$DIR/persist-netdump"
 ln -s /persist/kcrashes     "$DIR/persist-kcrashes"
 ln -s /run                  "$DIR/root-run"
@@ -464,13 +465,14 @@ fi
 # Make a tarball
 # --exlude='root-run/run'              /run/run/run/.. exclude symbolic link loop
 # --exclude='root-run/containerd-user'  the k8s.io/*/rootfs paths go deep
+# --exclude='persist-kubelog/save-var-lib'  /persist/kubelog/save-var-lib/.. exclude the saved /var/lib
 # --ignore-failed-read --warning=none  ignore all errors, even if read fails
 # --dereference                        follow symlinks
 echo "- tar/gzip"
 if check_tar_flags; then
-  tar -C "$TMP_DIR" --exclude='root-run/run' --exclude='root-run/containerd-user' --ignore-failed-read --warning=none --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
+  tar -C "$TMP_DIR" --exclude='root-run/run' --exclude='root-run/containerd-user' --exclude='persist-kubelog/save-var-lib' --ignore-failed-read --warning=none --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
 else
-  tar -C "$TMP_DIR" --exclude='root-run/run' --exclude='root-run/containerd-user' --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
+  tar -C "$TMP_DIR" --exclude='root-run/run' --exclude='root-run/containerd-user' --exclude='persist-kubelog/save-var-lib' --dereference -czf "$TARBALL_FILE" "$INFO_DIR"
 fi
 rm -rf "$TMP_DIR"
 sync

--- a/pkg/pillar/cmd/zedkube/kubeinterface.go
+++ b/pkg/pillar/cmd/zedkube/kubeinterface.go
@@ -480,17 +480,15 @@ func handleClusterStatus(ctx *zedkubeContext) {
 }
 
 func statusHandler(w http.ResponseWriter, r *http.Request, ctx *zedkubeContext) {
-	if ctx.config == nil {
-		config, err := kubeapi.GetKubeConfig()
-		if err != nil {
-			fmt.Fprint(w, "")
-			log.Errorf("statusHandler: can't get kubeconfig %v", err)
-			return
-		}
-		ctx.config = config
+	config, err := kubeapi.GetKubeConfig()
+	if err != nil {
+		fmt.Fprint(w, "")
+		log.Errorf("statusHandler: can't get kubeconfig %v", err)
+		return
 	}
+	ctx.config = config
 
-	clientset, err := kubernetes.NewForConfig(ctx.config)
+	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Errorf("statusHandler: can't get clientset %v", err)
 		fmt.Fprint(w, "")


### PR DESCRIPTION
- not to use kubeconfig cache in zedkube, cluster will change certificates
- put in the /persist/kubelog into collect-init.sh