### PR TITLE
Some additonal changes to kube container and k3s config

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -3,6 +3,8 @@
 
 write-kubeconfig-mode: "0644"
 log: "/persist/kubelog/k3s.log"
+# disable agent tunneling, we are on the same network
+egress-selector-mode: "disabled"
 # Use longhorn storage
 disable: local-storage
 etcd-arg:

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1102,9 +1102,8 @@ func initPublications(zedagentCtx *zedagentContext) {
 	getconfigCtx.pubZedAgentStatus.ClearRestarted()
 
 	zedagentCtx.pubEdgeNodeClusterConfig, err = ps.NewPublication(pubsub.PublicationOptions{
-		AgentName:  agentName,
-		Persistent: true,
-		TopicType:  types.EdgeNodeClusterConfig{},
+		AgentName: agentName,
+		TopicType: types.EdgeNodeClusterConfig{},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/zedkube/kubeinterface.go
+++ b/pkg/pillar/cmd/zedkube/kubeinterface.go
@@ -168,6 +168,13 @@ func drainAndDeleteNode(ctx *zedkubeContext) {
 	node := nodes.Items[0]
 	nodeName := node.Name
 
+	// cordon the node first
+	node.Spec.Unschedulable = true
+	_, err = clientset.CoreV1().Nodes().Update(context.Background(), &node, metav1.UpdateOptions{})
+	if err != nil {
+		log.Errorf("drainAndDeleteNode: cordon node %s failed: %v, continue the delete", nodeName, err)
+	}
+
 	// there is pkg: k8s.io/kubectl/pkg/drain, but it brings in many dependencies in vendor files
 	// implement here a simple 'drain', mainly to delete the pods on the node before we delete the node
 	// even if there are still pods on the node when deleting the node, we use replicaSet, and it is fine

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -345,7 +345,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.EdgeNodeClusterConfig{},
-		Persistent:    true,
 		Activate:      false,
 		Ctx:           &zedkubeCtx,
 		CreateHandler: handleEdgeNodeClusterConfigCreate,


### PR DESCRIPTION
- kube k3s restart log taken only the last restart part instead of the current entire k3s.log file
- change the check_cluster_config_change to a separate task loop than the main cluster-init.sh loop, we can be stuck in certain condition and can not get out in order to check the cluster status change. This is to allow under any condition, we can get out of trouble and convert itself into a single-node, then convert back to cluster if needed
- when the bootstrap node is removed, the k3s/etcd keep generating large amount of logs, complainting about can not connect to proxy server, which is I think due to the 'agent tunneling' in k3s. Since we require all the nodes on the same network, we don't need this 'agent tunneling'. Thus set 'egress-selector-mode' to 'disabled' in k3s config file
- move the zedagent publish of 'EdgeNodeClusterConfig' away from /persist/status, since we have the check-point, that should be good enough, and it does not need /persist directory
- added node 'corden' the the 'drainAndDeleteNode()' when changing from cluster mode back into single-node mode.