### PR TITLE
Move back for EdgeNodeClusterConfig to /persist

### DIFF
--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1102,8 +1102,9 @@ func initPublications(zedagentCtx *zedagentContext) {
 	getconfigCtx.pubZedAgentStatus.ClearRestarted()
 
 	zedagentCtx.pubEdgeNodeClusterConfig, err = ps.NewPublication(pubsub.PublicationOptions{
-		AgentName: agentName,
-		TopicType: types.EdgeNodeClusterConfig{},
+		AgentName:  agentName,
+		Persistent: true,
+		TopicType:  types.EdgeNodeClusterConfig{},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -345,6 +345,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.EdgeNodeClusterConfig{},
+		Persistent:    true,
 		Activate:      false,
 		Ctx:           &zedkubeCtx,
 		CreateHandler: handleEdgeNodeClusterConfigCreate,


### PR DESCRIPTION
- seen an issue when upgrade EVE image fails, the zedagent does not publish the ENC config using the previously check-pointed data. Causing the kube contain to decides moving to single-node mode even though it just connecting to the controller takes a while.
- skip the token change on non-bootstrap node, it does not seem to be necessary and can also causing issues
- in cluster-change background task, need to wait if the main task is in transition into cluster while waiting for the cluster status.