### PR TITLE
Add a check during startup to prevent switch to single node accidentally

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -735,6 +735,12 @@ check_cluster_config_change() {
       if [ ! -f /var/lib/edge-node-cluster-mode ]; then
         return 0
       else
+        # check to see if the persistent config file exists, if yes, then we need to
+        # wait until zedkube to publish the ENC status file
+        if [ -f /persist/status/zedagent/EdgeNodeClusterConfig/global.json ]; then
+          logmsg "EdgeNodeClusterConfig file found, but the EdgeNodeClusterStatus file is missing, wait..."
+          return 0
+        fi
         touch /var/lib/convert-to-single-node
         reboot
       fi

--- a/pkg/pillar/cmd/zedkube/kubeinterface.go
+++ b/pkg/pillar/cmd/zedkube/kubeinterface.go
@@ -14,11 +14,9 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/cipher"
-	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/vishvananda/netlink"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 func runKubeConfig(ctx *zedkubeContext, config, oldconfig *types.EdgeNodeClusterConfig, isDel bool) {


### PR DESCRIPTION
- there could be a case zedkube publish the EdgeNodeCLusterStatus too late and kube accidentally switch into single-node mode