### PR TITLE
Changed waitForNodeReady to look for No. of pod items < 4

### DIFF
--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -285,7 +285,7 @@ func waitForNodeReady(client *kubernetes.Clientset, readyCh chan bool, devUUID s
 			if err != nil {
 				return err
 			}
-			if len(pods.Items) < 6 {
+			if len(pods.Items) < 4 {
 				return fmt.Errorf("kubevirt running pods less than 6")
 			}
 


### PR DESCRIPTION
The default replica of virt-controller and virt-operator were two, resulting in a total of 6 pods. As the replica is modified to default to one, changing pods count to four. 