### PR TITLE
Add mechanism for application/container migration in cluster

### DIFF
--- a/pkg/pillar/base/kubevirt.go
+++ b/pkg/pillar/base/kubevirt.go
@@ -115,3 +115,15 @@ func GetVMINameFromVirtLauncher(podName string) (vmiName string, isVirtLauncher 
 	}
 	return vmiName, true
 }
+
+func GetReplicaPodName(displayName, podName string, uuid uuid.UUID) (kubeName string, isReplicaPod bool) {
+	kubeName = GetAppKubeName(displayName, uuid)
+	if !strings.HasPrefix(podName, kubeName) {
+		return "", false
+	}
+	suffix := strings.TrimPrefix(podName, kubeName)
+	if strings.HasPrefix(suffix, "-") && len(suffix[1:]) == 5 {
+		return kubeName, true
+	}
+	return "", false
+}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -17,8 +17,8 @@ import (
 // XXX hack for now to block and using hostname
 func handleVolumeClusterForUs(config types.VolumeConfig) bool {
 	devUUIDStr, _ := os.Hostname()
-	if config.DesignatedNodeID != uuid.Nil && config.DesignatedNodeID.String() != devUUIDStr {
-		log.Noticef("handleContentTreeCreate(%s) not for us", config.Key())
+	if config.DesignatedNodeID != uuid.Nil && config.DesignatedNodeID.String() != devUUIDStr && !config.IsNoHyper {
+		log.Noticef("handleVolumeClusterForUs(%s) not for us", config.Key())
 		return false
 	}
 	return true

--- a/pkg/pillar/cmd/zedagent/clusterpubsub.go
+++ b/pkg/pillar/cmd/zedagent/clusterpubsub.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
@@ -101,6 +102,9 @@ func handleEncPubToRemoteDataImp(ctxArg interface{}, key string, configArg inter
 			log.Noticef("handleEncPubToRemoteDataImp(%s) VC create/update %v", key, vcconfig)
 			getconfigCtx.pubVolumeConfig.Publish(key, vcconfig)
 		}
+		time.Sleep(3 * time.Second)
+		signalVolumeConfigRestarted(getconfigCtx) // XXX hack here for cluster pubsub
+		log.Noticef("handleEncPubToRemoteDataImp(%s) VC signalVolumeConfigRestarted", key)
 	case types.EncDataStoreConfig:
 		var dsconfig types.DatastoreConfig
 		err := decodeGobData(encCfg.AgentData, &dsconfig)

--- a/pkg/pillar/cmd/zedagent/handlecontent.go
+++ b/pkg/pillar/cmd/zedagent/handlecontent.go
@@ -103,6 +103,7 @@ func parseContentInfoConfig(ctx *getconfigContext,
 				if volume.ContentID == contentConfig.ContentID {
 					if volume.DesignatedNodeID != uuid.Nil {
 						contentConfig.DesignatedNodeID = volume.DesignatedNodeID
+						contentConfig.IsNoHyper = volume.IsNoHyper
 						log.Noticef("parseContentInfo designated ID copy from volume config: %v, contentid %v, url %s", contentConfig.DesignatedNodeID, contentConfig.ContentID, contentConfig.RelativeURL)
 					}
 				}

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -130,8 +130,7 @@ func parseVolumeConfig(ctx *getconfigContext,
 				origDNID := ct.DesignatedNodeID
 				if volumeConfig.DesignatedNodeID != uuid.Nil && ct.ContentID == volumeConfig.ContentID {
 					ct.DesignatedNodeID = volumeConfig.DesignatedNodeID
-					log.Noticef("parseVolumeConfig designated ID copy to content tree: %v, contend id %v, url %s",
-						ct.DesignatedNodeID, ct.ContentID, ct.RelativeURL)
+					ct.IsNoHyper = volumeConfig.IsNoHyper
 				}
 				if origDNID != ct.DesignatedNodeID {
 					log.Noticef("parseVolumeConfig: pub content tree config update %s", ct.Key())

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
 )
 
 // MaybeAddDomainConfig makes sure we have a DomainConfig
@@ -37,6 +38,11 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	if ns != nil {
 		AppNum = ns.AppNum
 	}
+
+	isDNiDnode := false
+	if aiConfig.DesignatedNodeID != uuid.Nil && aiConfig.DesignatedNodeID == ctx.nodeUUID {
+		isDNiDnode = true
+	}
 	effectiveActivate := effectiveActivateCombined(aiConfig, ctx)
 	dc := types.DomainConfig{
 		UUIDandVersion:    aiConfig.UUIDandVersion,
@@ -51,6 +57,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		MetaDataType:      aiConfig.MetaDataType,
 		Service:           aiConfig.Service,
 		CloudInitVersion:  aiConfig.CloudInitVersion,
+		IsDNidNode:        isDNiDnode,
 	}
 
 	dc.DiskConfigList = make([]types.DiskConfig, 0, len(aiStatus.VolumeRefStatusList))

--- a/pkg/pillar/cmd/zedrouter/cni.go
+++ b/pkg/pillar/cmd/zedrouter/cni.go
@@ -333,6 +333,10 @@ func (z *zedrouter) getAppByPodName(
 	for _, item := range z.pubAppNetworkStatus.GetAll() {
 		appStatus := item.(types.AppNetworkStatus)
 		appUUID := appStatus.UUIDandVersion.UUID
+		repPodName, isReplicaPod := base.GetReplicaPodName(appStatus.DisplayName, podName, appUUID)
+		if isReplicaPod {
+			appKubeName = repPodName
+		}
 		if base.GetAppKubeName(appStatus.DisplayName, appUUID) == appKubeName {
 			appConfig := z.lookupAppNetworkConfig(appStatus.Key())
 			if appConfig == nil {

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -97,7 +97,7 @@ func (ctx ctrdContext) setupSpec(status *types.DomainStatus, config *types.Domai
 }
 
 func (ctx ctrdContext) Setup(status types.DomainStatus, config types.DomainConfig,
-	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
+	aa *types.AssignableAdapters, nodeName string, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 	if status.OCIConfigDir == "" {
 		return logError("failed to run domain %s: not based on an OCI image", status.DomainName)
 	}

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -27,6 +27,7 @@ import (
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -47,12 +48,22 @@ const (
 	waitForPodCheckTime    = 15 // Check every 15 seconds, don't wait for too long to cause watchdog
 )
 
+type MetaDataType int
+
+// Constants representing different resource types.
+const (
+	IsMetaVmi MetaDataType = iota
+	IsMetaReplicaSet
+	IsMetaPod
+)
+
 // VM instance meta data structure.
 type vmiMetaData struct {
 	vmi      *v1.VirtualMachineInstance // Handle to the VM instance
 	pod      *k8sv1.Pod                 // Handle to the pod container
+	replica  *appsv1.ReplicaSet         // Handle to the replicaSetof pod
 	domainID int                        // DomainID understood by domainmgr in EVE
-	isPod    bool                       // switch on is Pod or is VMI
+	mtype    MetaDataType               // switch on is ReplicaSet, Pod or is VMI
 	name     string                     // Display-Name(all lower case) + first 5 bytes of domainName
 	cputotal uint64                     // total CPU in NS so far
 	maxmem   uint32                     // total Max memory usage in bytes so far
@@ -66,12 +77,14 @@ type kubevirtContext struct {
 	virthandlerIPAddr string
 	prevDomainMetric  map[string]types.DomainMetric
 	kubeConfig        *rest.Config
+	nodeNameMap       map[string]string // to pass nodeName between methods without pointer receiver
 }
 
 // Use few states  for now
 var stateMap = map[string]types.SwState{
 	"Paused":     types.PAUSED,
 	"Running":    types.RUNNING,
+	"NonLocal":   types.RUNNING,
 	"shutdown":   types.HALTING,
 	"suspended":  types.PAUSED,
 	"Pending":    types.PENDING,
@@ -131,6 +144,7 @@ func newKubevirt() Hypervisor {
 			devicemodel:      "virt",
 			vmiList:          make(map[string]*vmiMetaData),
 			prevDomainMetric: make(map[string]types.DomainMetric),
+			nodeNameMap:      make(map[string]string),
 		}
 	case "amd64":
 		return kubevirtContext{
@@ -138,6 +152,7 @@ func newKubevirt() Hypervisor {
 			devicemodel:      "pc-q35-3.1",
 			vmiList:          make(map[string]*vmiMetaData),
 			prevDomainMetric: make(map[string]types.DomainMetric),
+			nodeNameMap:      make(map[string]string),
 		}
 	}
 	return nil
@@ -184,16 +199,18 @@ func (ctx kubevirtContext) Task(status *types.DomainStatus) types.Task {
 
 // Use eve DomainConfig and DomainStatus and generate k3s VMI config or a Pod config
 func (ctx kubevirtContext) Setup(status types.DomainStatus, config types.DomainConfig,
-	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
+	aa *types.AssignableAdapters, nodeName string, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 
 	diskStatusList := status.DiskStatusList
 	domainName := status.DomainName
 
 	logrus.Debugf("Setup called for Domain: %s, vmmode %v", domainName, config.VirtualizationMode)
 
+	getMyNodeUUID(&ctx, nodeName)
+
 	if config.VirtualizationMode == types.NOHYPER {
-		if err := ctx.CreatePodConfig(domainName, config, status, diskStatusList, aa, file); err != nil {
-			return logError("failed to build kube pod config: %v", err)
+		if err := ctx.CreateReplicaSetConfig(domainName, config, status, diskStatusList, aa, file); err != nil {
+			return logError("failed to build kube replicaset config: %v", err)
 		}
 	} else {
 		// Take eve domain config and convert to VMI config
@@ -225,16 +242,10 @@ func (ctx kubevirtContext) CreateVMIConfig(domainName string, config types.Domai
 		return err
 	}
 
-	// Get the my node name from cluster
-	hostname, _ := os.Hostname()
-	nodeName, err := kubeapi.GetNodeNameFromDevUUID(hostname)
-	if err != nil {
-		logrus.Errorf("CreateVMIConfig: failed to get node name %v", err)
-		return err
-	} else {
-		logrus.Infof("CreateVMIConfig: got node name %s", nodeName)
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		return logError("Failed to get nodeName")
 	}
-
 	kubeName := base.GetAppKubeName(config.DisplayName, config.UUIDandVersion.UUID)
 	// Get a VirtualMachineInstance object and populate the values from DomainConfig
 	vmi := v1.NewVMIReferenceFromNameWithNS(kubeapi.EVEKubeNameSpace, kubeName)
@@ -469,12 +480,13 @@ func (ctx kubevirtContext) Start(domainName string) error {
 	}
 	kubeconfig := ctx.kubeConfig
 
+	logrus.Infof("Starting Kubevirt domain %s, devicename nodename %d", domainName, len(ctx.nodeNameMap))
 	vmis, ok := ctx.vmiList[domainName]
 	if !ok {
 		return logError("start domain %s failed to get vmlist", domainName)
 	}
-	if vmis.isPod {
-		err := StartPodContainer(kubeconfig, ctx.vmiList[domainName].pod)
+	if vmis.mtype == IsMetaReplicaSet {
+		err := StartReplicaSetContiner(ctx, ctx.vmiList[domainName].replica)
 		return err
 	}
 
@@ -533,8 +545,8 @@ func (ctx kubevirtContext) Stop(domainName string, force bool) error {
 	if !ok {
 		return logError("domain %s failed to get vmlist", domainName)
 	}
-	if vmis.isPod {
-		err := StopPodContainer(ctx, kubeconfig, vmis.name)
+	if vmis.mtype == IsMetaReplicaSet {
+		err := StopReplicaSetContainer(kubeconfig, vmis.name)
 		return err
 	} else {
 		virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
@@ -570,8 +582,8 @@ func (ctx kubevirtContext) Delete(domainName string) (result error) {
 	if !ok {
 		return logError("delete domain %s failed to get vmlist", domainName)
 	}
-	if vmis.isPod {
-		err := StopPodContainer(ctx, kubeconfig, vmis.name)
+	if vmis.mtype == IsMetaReplicaSet {
+		err := StopReplicaSetContainer(kubeconfig, vmis.name)
 		return err
 	} else {
 		virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
@@ -623,8 +635,8 @@ func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
 	if !ok {
 		return 0, types.HALTED, logError("info domain %s failed to get vmlist", domainName)
 	}
-	if vmis.isPod {
-		res, err = InfoPodContainer(ctx.kubeConfig, vmis.name)
+	if vmis.mtype == IsMetaReplicaSet {
+		res, err = InfoReplicaSetContainer(ctx, vmis.name)
 	} else {
 		res, err = getVMIStatus(vmis.name)
 	}
@@ -653,7 +665,11 @@ func (ctx kubevirtContext) Cleanup(domainName string) error {
 	if !ok {
 		return logError("cleanup domain %s failed to get vmlist", domainName)
 	}
-	if vmis.isPod {
+	if vmis.mtype == IsMetaReplicaSet {
+		_, err = InfoReplicaSetContainer(ctx, vmis.name)
+		if err == nil {
+			err = ctx.Delete(domainName)
+		}
 	} else {
 		err = waitForVMI(vmis.name, false)
 	}
@@ -878,10 +894,8 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 	}
 
 	hasEmptyRes := len(ctx.vmiList) - len(res)
-	if hasEmptyRes > 0 {
-		// check and get the kubernetes pod's metrics
-		checkPodMetrics(ctx, res, hasEmptyRes)
-	}
+	checkReplicaSetMetrics(ctx, res, hasEmptyRes)
+
 	logrus.Debugf("GetDomsCPUMem: %d VMs: %+v, podnum %d", len(ctx.vmiList), res, hasEmptyRes)
 	return res, nil
 }
@@ -945,31 +959,21 @@ func assignToInt64(parsedValue interface{}) int64 {
 	return intValue
 }
 
-func (ctx kubevirtContext) CreatePodConfig(domainName string, config types.DomainConfig, status types.DomainStatus,
+func (ctx kubevirtContext) CreateReplicaSetConfig(domainName string, config types.DomainConfig, status types.DomainStatus,
 	diskStatusList []types.DiskStatus, aa *types.AssignableAdapters, file *os.File) error {
 
 	kubeName := base.GetAppKubeName(config.DisplayName, config.UUIDandVersion.UUID)
 	if config.KubeImageName == "" {
 		err := fmt.Errorf("domain config kube image name empty")
-		logrus.Errorf("CreatePodConfig: %v", err)
+		logrus.Errorf("CreateReplicaSetConfig: %v", err)
 		return err
 	}
 	ociName := config.KubeImageName
 
-	// Get the my node name from cluster
-	hostname, _ := os.Hostname()
-	nodeName, err := kubeapi.GetNodeNameFromDevUUID(hostname)
-	if err != nil {
-		logrus.Errorf("CreatePodConfig: failed to get node name %v", err)
-		return err
-	} else {
-		logrus.Infof("CreatePodConfig: got node name %s", nodeName)
-	}
-	if err != nil {
-		logrus.Errorf("CreatePodConfig: failed to get node name %v", err)
-		return err
-	} else {
-		logrus.Infof("CreatePodConfig: got node name %s", nodeName)
+	logrus.Infof("CreateReplicaSetConfig: domainName %s, kubeName %s, nodeName %d", domainName, kubeName, len(ctx.nodeNameMap))
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		return logError("Failed to get nodeName")
 	}
 
 	var netSelections []netattdefv1.NetworkSelectionElement
@@ -992,7 +996,7 @@ func (ctx kubevirtContext) CreatePodConfig(domainName string, config types.Domai
 			// Check if the NAD is created in the cluster, return error if not
 			err := kubeapi.CheckEtherPassThroughNAD(nadName)
 			if err != nil {
-				logrus.Errorf("CreatePodConfig: check ether NAD failed, %v", err)
+				logrus.Errorf("CreateReplicaSetConfig: check ether NAD failed, %v", err)
 				return err
 			}
 		}
@@ -1003,71 +1007,95 @@ func (ctx kubevirtContext) CreatePodConfig(domainName string, config types.Domai
 		annotations = map[string]string{
 			"k8s.v1.cni.cncf.io/networks": encodeSelections(netSelections),
 		}
-		logrus.Infof("CreatePodConfig: annotations %+v", annotations)
+		logrus.Infof("CreateReplicaSetConfig: annotations %+v", annotations)
 	} else {
-		err := fmt.Errorf("CreatePodConfig: no network selections, exit")
+		err := fmt.Errorf("CreateReplicaSetConfig: no network selections, exit")
 		return err
 	}
 
-	vcpus := strconv.Itoa(config.VCpus*1000) + "m"
+	//vcpus := strconv.Itoa(config.VCpus*1000) + "m"
 	// FixedResources.Memory is in Kbytes
-	memoryLimit := strconv.Itoa(config.Memory * 1000)
-	memoryRequest := strconv.Itoa(config.Memory * 1000)
+	//memoryLimit := "100Mi" // convertToKubernetesFormat(config.Memory * 1000)
+	//memoryRequest := memoryLimit
 
-	pod := &k8sv1.Pod{
+	var replicaNum int32
+	var tolerateSec int64
+	replicaNum = 1
+	//tolerateSec = 420 // try 7 minutes
+	tolerateSec = 30 // try half a minute to see
+	repNum := &replicaNum
+	tolSec := &tolerateSec
+	replicaSet := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        kubeName,
-			Namespace:   kubeapi.EVEKubeNameSpace,
-			Annotations: annotations,
+			Name:      kubeName,
+			Namespace: kubeapi.EVEKubeNameSpace,
 		},
-		Spec: k8sv1.PodSpec{
-			Containers: []k8sv1.Container{
-				{
-					Name:            kubeName,
-					Image:           ociName,
-					ImagePullPolicy: k8sv1.PullNever,
-					SecurityContext: &k8sv1.SecurityContext{
-						Privileged: &[]bool{true}[0],
-					},
-					Resources: k8sv1.ResourceRequirements{
-						Limits: k8sv1.ResourceList{
-							k8sv1.ResourceCPU:    resource.MustParse(vcpus),
-							k8sv1.ResourceMemory: resource.MustParse(memoryLimit),
-						},
-						Requests: k8sv1.ResourceList{
-							k8sv1.ResourceCPU:    resource.MustParse(vcpus),
-							k8sv1.ResourceMemory: resource.MustParse(memoryRequest),
-						},
-					},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: repNum,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": kubeName,
 				},
 			},
-			RestartPolicy: k8sv1.RestartPolicyAlways,
-			DNSConfig: &k8sv1.PodDNSConfig{
-				Nameservers: []string{"8.8.8.8", "1.1.1.1"}, // XXX, temp, Add your desired DNS servers here
-			},
-		},
-	}
-	pod.Labels = make(map[string]string)
-	pod.Labels[eveLabelKey] = domainName
-	affinity := &k8sv1.Affinity{
-		NodeAffinity: &k8sv1.NodeAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []k8sv1.PreferredSchedulingTerm{
-				{
-					Preference: k8sv1.NodeSelectorTerm{
-						MatchExpressions: []k8sv1.NodeSelectorRequirement{
-							{
-								Key:      "kubernetes.io/hostname",
-								Operator: "In",
-								Values:   []string{nodeName},
+			Template: k8sv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": kubeName,
+					},
+					Annotations: annotations,
+				},
+				Spec: k8sv1.PodSpec{
+					Tolerations: []k8sv1.Toleration{
+						{
+							Key:               "node.kubernetes.io/unreachable",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: tolSec,
+						},
+						{
+							Key:               "node.kubernetes.io/not-ready",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: tolSec,
+						},
+					},
+					Affinity: &k8sv1.Affinity{
+						NodeAffinity: &k8sv1.NodeAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []k8sv1.PreferredSchedulingTerm{
+								{
+									Preference: k8sv1.NodeSelectorTerm{
+										MatchExpressions: []k8sv1.NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/hostname",
+												Operator: "In",
+												Values:   []string{nodeName},
+											},
+										},
+									},
+									Weight: 100,
+								},
 							},
 						},
 					},
-					Weight: 100,
+					Containers: []k8sv1.Container{
+						{
+							Name:            kubeName,
+							Image:           ociName,
+							ImagePullPolicy: k8sv1.PullNever,
+							SecurityContext: &k8sv1.SecurityContext{
+								Privileged: &[]bool{true}[0],
+							},
+						},
+					},
+					RestartPolicy: k8sv1.RestartPolicyAlways,
+					DNSConfig: &k8sv1.PodDNSConfig{
+						Nameservers: []string{"8.8.8.8", "1.1.1.1"}, // XXX, temp, Add your desired DNS servers here
+					},
 				},
 			},
 		},
 	}
-	pod.Spec.Affinity = affinity
+	logrus.Infof("CreateReplicaSetConfig: replicaset %+v", replicaSet)
 
 	// Add pod non-image volume disks
 	if len(diskStatusList) > 1 {
@@ -1083,59 +1111,307 @@ func (ctx kubevirtContext) CreatePodConfig(domainName string, config types.Domai
 		}
 		if leng > 0 {
 			volumes := make([]k8sv1.Volume, leng)
-			voldevs := make([]k8sv1.VolumeDevice, leng)
-			//mounts := make([]k8sv1.VolumeMount, leng)
+			mounts := make([]k8sv1.VolumeMount, leng)
 
 			i := 0
 			for _, ds := range diskStatusList[1:] {
 				if ds.Devtype == "9P" {
 					continue
 				}
-				pvcName, err := ds.GetPVCNameFromVolumeKey()
-				if err != nil {
-					return logError("CreatePodConfig: Failed to fetch PVC Name from volumekey %v", ds.VolumeKey)
-				}
-
 				voldispName := strings.ToLower(ds.DisplayName)
-				voldevs[i] = k8sv1.VolumeDevice{
-					Name:       voldispName,
-					DevicePath: ds.MountDir,
-				}
-				//mounts[i] = k8sv1.VolumeMount{
-				//	Name:      voldispName,
-				//	MountPath: ds.MountDir,
+				//voldevs[i] = k8sv1.VolumeDevice{
+				//	Name:       voldispName,
+				//	DevicePath: ds.MountDir,
 				//}
+				mounts[i] = k8sv1.VolumeMount{
+					Name:      voldispName,
+					MountPath: ds.MountDir,
+				}
 
 				volumes[i].Name = voldispName
 				volumes[i].VolumeSource = k8sv1.VolumeSource{
 					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-						ClaimName: pvcName,
+						ClaimName: strings.ToLower(ds.DisplayName),
+						//ClaimName: ds.VolumeKey,
 					},
 				}
+				logrus.Infof("CreateReplicaSetConfig:(%d) mount[i] %+v, volumes[i] %+v", i, mounts[i], volumes[i])
 				i++
 			}
-			pod.Spec.Containers[0].VolumeDevices = voldevs
-			//pod.Spec.Containers[0].VolumeMounts = mounts
-			pod.Spec.Volumes = volumes
+			replicaSet.Spec.Template.Spec.Containers[0].VolumeMounts = mounts
+			replicaSet.Spec.Template.Spec.Volumes = volumes
 		}
 	}
-	logrus.Infof("CreatePodConfig: pod setup %+v", pod)
+	logrus.Infof("CreateReplicaSetConfig: replicaset setup %+v", replicaSet)
 
 	// Now we have VirtualMachine Instance object, save it to config file for debug purposes
 	// and save it in context which will be used to start VM in Start() call
 	meta := vmiMetaData{
-		pod:      pod,
-		isPod:    true,
+		replica:  replicaSet,
+		mtype:    IsMetaReplicaSet,
 		name:     kubeName,
 		domainID: int(rand.Uint32()),
 	}
 	ctx.vmiList[domainName] = &meta
 
-	podStr := fmt.Sprintf("%+v", pod)
+	repStr := fmt.Sprintf("%+v", replicaSet)
 
 	// write to config file
-	file.WriteString(podStr)
+	file.WriteString(repStr)
 
+	return nil
+}
+
+func StartReplicaSetContiner(ctx kubevirtContext, rep *appsv1.ReplicaSet) error {
+	err := getConfig(&ctx)
+	if err != nil {
+		return err
+	}
+	clientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
+	if err != nil {
+		logrus.Errorf("StartReplicaSetContiner: can't get clientset %v", err)
+		return err
+	}
+
+	opStr := "created"
+	result, err := clientset.AppsV1().ReplicaSets(kubeapi.EVEKubeNameSpace).Create(context.TODO(), rep, metav1.CreateOptions{})
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			logrus.Errorf("StartReplicaSetContiner: replicaset create failed: %v", err)
+			return err
+		} else {
+			opStr = "already exists"
+		}
+	}
+
+	logrus.Infof("StartReplicaSetContiner: Rep %s %s, result %v", rep.ObjectMeta.Name, opStr, result)
+
+	err = checkForReplicaSet(ctx, rep.ObjectMeta.Name)
+	if err != nil {
+		logrus.Errorf("StartReplicaSetContiner: check for pod status error %v", err)
+		return err
+	}
+	logrus.Infof("StartReplicaSetContiner: Pod %s running", rep.ObjectMeta.Name)
+	return nil
+}
+
+func checkForReplicaSet(ctx kubevirtContext, repName string) error {
+	var i int
+	var status string
+	var err error
+	for {
+		i++
+		logrus.Infof("checkForReplicaSet: check(%d) wait 15 sec, %v", i, repName)
+		time.Sleep(15 * time.Second)
+
+		status, err = InfoReplicaSetContainer(ctx, repName)
+		if err != nil {
+			logrus.Infof("checkForReplicaSet: repName %s, %v", repName, err)
+		} else {
+			if status == "Running" || status == "NonLocal" {
+				logrus.Infof("checkForReplicaSet: (%d) status %s, good", i, status)
+				return nil
+			} else {
+				logrus.Errorf("checkForReplicaSet(%d): get podName info status %v (not running)", i, status)
+			}
+		}
+		if i > waitForPodCheckCounter {
+			break
+		}
+	}
+
+	return fmt.Errorf("checkForReplicaSet: timed out, statuus %s, err %v", status, err)
+}
+
+func InfoReplicaSetContainer(ctx kubevirtContext, repName string) (string, error) {
+
+	err := getConfig(&ctx)
+	if err != nil {
+		return "", err
+	}
+	podclientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
+	if err != nil {
+		return "", logError("InfoReplicaSetContainer: couldn't get the pod Config: %v", err)
+	}
+
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		return "", logError("Failed to get nodeName")
+	}
+	pods, err := podclientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", repName),
+	})
+	if err != nil {
+		return "", logError("InfoReplicaSetContainer: couldn't get the pods: %v", err)
+	}
+
+	var foundNonlocal bool
+	for _, pod := range pods.Items {
+		if nodeName != pod.Spec.NodeName {
+			foundNonlocal = true
+			logrus.Infof("InfoReplicaSetContainer: rep %s, nodeName %v differ w/ hostname", repName, pod.Spec.NodeName)
+			continue
+		}
+
+		var res string
+		// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+		switch pod.Status.Phase {
+		case k8sv1.PodPending:
+			res = "Pending"
+		case k8sv1.PodRunning:
+			res = "Running"
+		case k8sv1.PodSucceeded:
+			res = "Running"
+		case k8sv1.PodFailed:
+			res = "Failed"
+		case k8sv1.PodUnknown:
+			res = "Scheduling"
+		default:
+			res = "Scheduling"
+		}
+		logrus.Infof("InfoReplicaSetContainer: rep %s, nodeName %v, status %s", pod.ObjectMeta.Name, pod.Spec.NodeName, res)
+		if pod.Status.Phase != k8sv1.PodRunning {
+			continue
+		}
+
+		return res, nil
+	}
+	if foundNonlocal {
+		return "NonLocal", nil
+	}
+	return "", logError("InfoReplicaSetContainer: pod not ready")
+}
+
+func checkReplicaSetMetrics(ctx kubevirtContext, res map[string]types.DomainMetric, emptySlot int) {
+
+	err := getConfig(&ctx)
+	if err != nil {
+		return
+	}
+	kubeconfig := ctx.kubeConfig
+	podclientset, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		logrus.Errorf("checkReplicaSetMetrics: can not get pod client %v", err)
+		return
+	}
+
+	clientset, err := metricsv.NewForConfig(kubeconfig)
+	if err != nil {
+		logrus.Errorf("checkReplicaSetMetrics: can't get clientset %v", err)
+		return
+	}
+
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		logrus.Errorf("checkReplicaSetMetrics: can't get node name") // XXX may remove
+		return
+	}
+
+	count := 0
+	for n, vmis := range ctx.vmiList {
+		if vmis.mtype != IsMetaReplicaSet {
+			continue
+		}
+		count++
+		repName := vmis.name
+		pods, err := podclientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("app=%s", repName),
+		})
+		if err != nil {
+			logrus.Errorf("checkReplicaSetMetrics: can't get pod %v", err)
+			continue
+		}
+
+		for _, pod := range pods.Items {
+			dm := getPodMetrics(clientset, pod, vmis, nodeName, res)
+			if dm != nil {
+				if count <= emptySlot {
+					res[n] = *dm
+				}
+				logrus.Infof("checkReplicaSetMetrics: dm %+v, res %v", dm, res)
+
+				ctx.vmiList[n] = vmis // update for the last seen metrics
+			}
+		}
+	}
+
+	logrus.Infof("checkReplicaSetMetrics: done with vmiList")
+}
+
+func getPodMetrics(clientset *metricsv.Clientset, pod k8sv1.Pod, vmis *vmiMetaData,
+	nodeName string, res map[string]types.DomainMetric) *types.DomainMetric {
+	if pod.Status.Phase != k8sv1.PodRunning {
+		return nil
+	}
+	if nodeName != pod.Spec.NodeName { // cluster, pod from other nodes
+		return nil
+	}
+	podName := pod.ObjectMeta.Name
+	memoryLimits := pod.Spec.Containers[0].Resources.Limits.Memory()
+
+	metrics, err := clientset.MetricsV1beta1().PodMetricses(kubeapi.EVEKubeNameSpace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		logrus.Errorf("checkReplicaSetMetrics: get pod metrics error %v", err)
+		return nil
+	}
+
+	cpuTotalNs := metrics.Containers[0].Usage[k8sv1.ResourceCPU]
+	cpuTotalNsAsFloat64 := cpuTotalNs.AsApproximateFloat64() * float64(time.Second) // get nanoseconds
+	totalCpu := uint64(cpuTotalNsAsFloat64)
+
+	//allocatedMemory := metrics.Containers[0].Usage[k8sv1.ResourceMemory]
+	usedMemory := metrics.Containers[0].Usage[k8sv1.ResourceMemory]
+	maxMemory := uint32(usedMemory.Value())
+	if vmis != nil {
+		if vmis.maxmem < maxMemory {
+			vmis.maxmem = maxMemory
+		} else {
+			maxMemory = vmis.maxmem
+		}
+	}
+
+	available := uint32(memoryLimits.Value())
+	if uint32(usedMemory.Value()) < available {
+		available = available - uint32(usedMemory.Value())
+	}
+	usedMemoryPercent := calculateMemoryUsagePercent(usedMemory.Value(), memoryLimits.Value())
+	BytesInMegabyte := uint32(1024 * 1024)
+
+	var realCPUTotal uint64
+	if vmis != nil {
+		realCPUTotal = vmis.cputotal + totalCpu
+		vmis.cputotal = realCPUTotal
+	}
+	dm := &types.DomainMetric{
+		CPUTotalNs:        realCPUTotal,
+		CPUScaled:         1,
+		AllocatedMB:       uint32(memoryLimits.Value()) / BytesInMegabyte,
+		UsedMemory:        uint32(usedMemory.Value()) / BytesInMegabyte,
+		MaxUsedMemory:     maxMemory / BytesInMegabyte,
+		AvailableMemory:   available / BytesInMegabyte,
+		UsedMemoryPercent: usedMemoryPercent,
+		NodeName:          pod.Spec.NodeName,
+	}
+	logrus.Infof("getPodMetrics: dm %+v, res %v", dm, res)
+	return dm
+}
+
+func StopReplicaSetContainer(kubeconfig *rest.Config, repName string) error {
+
+	clientset, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		logrus.Errorf("StopReplicaSetContainer: can't get clientset %v", err)
+		return err
+	}
+
+	err = clientset.AppsV1().ReplicaSets(kubeapi.EVEKubeNameSpace).Delete(context.TODO(), repName, metav1.DeleteOptions{})
+	if err != nil {
+		// Handle error
+		logrus.Errorf("StopReplicaSetContainer: deleting pod: %v", err)
+		return err
+	}
+
+	logrus.Infof("StopReplicaSetContainer: Pod %s deleted", repName)
 	return nil
 }
 
@@ -1148,112 +1424,22 @@ func encodeSelections(selections []netattdefv1.NetworkSelectionElement) string {
 	return string(bytes)
 }
 
-// StartPodContainer :  Starts container as kubernetes pod
-func StartPodContainer(kubeconfig *rest.Config, pod *k8sv1.Pod) error {
-
-	clientset, err := kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		logrus.Errorf("StartPodContainer: can't get clientset %v", err)
-		return err
-	}
-
-	opStr := "created"
-	_, err = clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).Create(context.TODO(), pod, metav1.CreateOptions{})
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			// TODO: update
-			logrus.Errorf("StartPodContainer: pod create filed: %v", err)
-			return err
-		} else {
-			opStr = "already exists"
-		}
-	}
-
-	logrus.Infof("StartPodContainer: Pod %s %s with nad %+v", pod.ObjectMeta.Name, opStr, pod.Annotations)
-
-	err = checkForPod(kubeconfig, pod.ObjectMeta.Name)
-	if err != nil {
-		logrus.Errorf("StartPodContainer: check for pod status error %v", err)
-		return err
-	}
-	logrus.Infof("StartPodContainer: Pod %s running", pod.ObjectMeta.Name)
-	return nil
-}
-
-func checkForPod(kubeconfig *rest.Config, podName string) error {
-	var i int
-	var status string
-	var err error
-	// wait for pod to be in running state, sometimes can take long, but we only wait for
-	// about a minute in order not to cause watchdog action
-	for {
-		i++
-		logrus.Infof("checkForPod: check(%d) wait 15 sec, %v", i, podName)
-		time.Sleep(waitForPodCheckTime * time.Second)
-
-		status, err = InfoPodContainer(kubeconfig, podName)
-		if err != nil {
-			logrus.Infof("checkForPod: podName %s, %v", podName, err)
-		} else {
-			if status == "Running" {
-				return nil
-			} else {
-				logrus.Errorf("checkForPod: get podName info status %v (not running)", status)
-			}
-		}
-		if i > waitForPodCheckCounter {
-			break
-		}
-	}
-
-	return fmt.Errorf("checkForPod: timed out, statuus %s, err %v", status, err)
-}
-
-// StopPodContainer : Stops the running kubernetes pod
-func StopPodContainer(ctx kubevirtContext, kubeconfig *rest.Config, podName string) error {
-
-	clientset, err := kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		logrus.Errorf("StopPodContainer: can't get clientset %v", err)
-		return err
-	}
-
-	err = clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
-	if err != nil {
-		// Handle error
-		logrus.Errorf("StopPodContainer: deleting pod: %v", err)
-		return err
-	}
-
-	// delete the pod from the vmiList mapping
-	for n, vmis := range ctx.vmiList {
-		if !vmis.isPod {
-			continue
-		}
-		if vmis.name == podName {
-			delete(ctx.vmiList, n)
-			break
-		}
-	}
-
-	logrus.Infof("StopPodContainer: Pod %s deleted", podName)
-	return nil
-}
-
 // InfoPodContainer : Get the pod information
-func InfoPodContainer(kubeconfig *rest.Config, podName string) (string, error) {
-
-	podclientset, err := kubernetes.NewForConfig(kubeconfig)
+func InfoPodContainer(ctx kubevirtContext, podName string) (string, error) {
+	err := getConfig(&ctx)
+	if err != nil {
+		return "", err
+	}
+	podclientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
 	if err != nil {
 		return "", logError("InfoPodContainer: couldn't get the pod Config: %v", err)
 	}
 
-	hostname, _ := os.Hostname()
-	nodeName, err := kubeapi.GetNodeNameFromDevUUID(hostname)
-	if err != nil {
-		logrus.Errorf("InfoPodContainer: failed to get node name %v", err)
-		return "", err
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		return "", logError("Failed to get nodeName")
 	}
+
 	pod, err := podclientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
 		return "", logError("InfoPodContainer: couldn't get the pod: %v", err)
@@ -1306,15 +1492,15 @@ func checkPodMetrics(ctx kubevirtContext, res map[string]types.DomainMetric, emp
 		return
 	}
 
-	hostname, _ := os.Hostname()
-	nodeName, err := kubeapi.GetNodeNameFromDevUUID(hostname)
-	if err != nil {
-		logrus.Errorf("checkPodMetrics: failed to get node name %v", err)
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		logrus.Errorf("checkPodMetrics: can't get node name") // XXX may remove
 		return
 	}
+
 	count := 0
 	for n, vmis := range ctx.vmiList {
-		if !vmis.isPod {
+		if vmis.mtype != IsMetaPod {
 			continue
 		}
 		count++
@@ -1513,4 +1699,10 @@ func (ctx kubevirtContext) PCIRelease(long string) error {
 // PCISameController checks if two PCI controllers are the same
 func (ctx kubevirtContext) PCISameController(id1 string, id2 string) bool {
 	return PCISameControllerGeneric(id1, id2)
+}
+
+func getMyNodeUUID(ctx *kubevirtContext, nodeName string) {
+	if len(ctx.nodeNameMap) == 0 {
+		ctx.nodeNameMap["nodename"] = nodeName
+	}
 }

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -668,7 +668,7 @@ func vmmOverhead(domainName string, domainUUID uuid.UUID, domainRAMSize int64, v
 
 // Setup sets up kvm
 func (ctx KvmContext) Setup(status types.DomainStatus, config types.DomainConfig,
-	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
+	aa *types.AssignableAdapters, nodeName string, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 
 	diskStatusList := status.DiskStatusList
 	domainName := status.DomainName

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -5,8 +5,9 @@ package hypervisor
 
 import (
 	"fmt"
-	"github.com/lf-edge/eve/pkg/pillar/types"
 	"os"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -66,7 +67,7 @@ func (ctx nullContext) Task(status *types.DomainStatus) types.Task {
 }
 
 func (ctx nullContext) Setup(types.DomainStatus, types.DomainConfig,
-	*types.AssignableAdapters, *types.ConfigItemValueMap, *os.File) error {
+	*types.AssignableAdapters, string, *types.ConfigItemValueMap, *os.File) error {
 	return nil
 }
 

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -119,7 +119,7 @@ func (ctx xenContext) Task(status *types.DomainStatus) types.Task {
 }
 
 func (ctx xenContext) Setup(status types.DomainStatus, config types.DomainConfig,
-	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap, file *os.File) error {
+	aa *types.AssignableAdapters, nodeName string, globalConfig *types.ConfigItemValueMap, file *os.File) error {
 	// first lets build the domain config
 	if err := ctx.CreateDomConfig(status.DomainName, config,
 		status.DiskStatusList, aa, globalConfig, file); err != nil {

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -29,8 +29,12 @@ type ContentTreeConfig struct {
 	GenerationCounter int64
 	DisplayName       string
 	CustomMeta        string
-	// XXX DesignatedNodeID
+	// DesignatedNodeID in cluster mode, with multiple nodes receiving the same
+	// content tree config, but only one Designated Node will download the
+	// content/volume and perform the PVC conversion tasks.
 	DesignatedNodeID uuid.UUID
+	// XXX is nohyper container
+	IsNoHyper bool
 }
 
 // Key is content info UUID which will be unique

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -41,6 +41,8 @@ type DomainConfig struct {
 	// KubeImageName: is the container image reference we pass to domainmgr to launch a native container
 	// in kubevirt eve
 	KubeImageName string
+	// if this node is the DNiD of the App
+	IsDNidNode bool
 
 	// XXX: to be deprecated, use CipherBlockStatus instead
 	CloudInitUserData *string `json:"pubsub-large-CloudInitUserData"` // base64-encoded
@@ -273,7 +275,7 @@ const (
 // Task represents any runnable entity on EVE
 type Task interface {
 	Setup(DomainStatus, DomainConfig, *AssignableAdapters,
-		*ConfigItemValueMap, *os.File) error
+		string, *ConfigItemValueMap, *os.File) error
 	Create(string, string, *DomainConfig) (int, error)
 	Start(string) error
 	Stop(string, bool) error
@@ -309,6 +311,8 @@ type DomainStatus struct {
 	WritableFiles  []cloudconfig.WritableFile // List of files from CloudInit scripts to be created in container
 	VmConfig                                  // From DomainConfig
 	Service        bool
+	// if this node is the DNiD of the App
+	IsDNidNode bool
 }
 
 func (status DomainStatus) Key() string {


### PR DESCRIPTION
- convert native container pod into replicatset
- use EdgeNodeInfo for getting the node name and uuid for domainmgr
- domainmgr prevent delete app due to app not showing up, it's a replicaset, domainmgr should not worry about deleting
- try to fillin the volumemgr Volume Reference name for container, which needs to be kept all the way through volumemgr -> zedmanager -> domainmgr
- some temp code on cluster pubsub
- generate uniform random Mac address across cluster nodes for App