### PR TITLE
Set nodename to lowercase when querying for pods

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -3641,7 +3641,7 @@ func getnodeNameAndUUID(ctx *domainContext) error {
 			return err
 		}
 		enInfo := NodeInfo.(types.EdgeNodeInfo)
-		ctx.nodeName = enInfo.DeviceName
+		ctx.nodeName = strings.ToLower(enInfo.DeviceName)
 		log.Noticef("**getnodeNameAndUUID: devicename, NodeInfo %v", NodeInfo) // XXX
 	}
 	return nil

--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -152,7 +152,7 @@ func checkAppsStatus(ctx *zedkubeContext) {
 	options := metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("spec.nodeName=%s", ctx.nodeName),
 	}
-	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.Background(), options)
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), options)
 	if err != nil {
 		log.Errorf("checkAppsStatus: can't get pods %v", err)
 		return
@@ -175,7 +175,7 @@ func checkAppsStatus(ctx *zedkubeContext) {
 		for _, pod := range pods.Items {
 			contVMIName := "virt-launcher-" + contName
 			log.Functionf("checkAppsStatus: pod %s, cont %s", pod.Name, contName)
-			if strings.HasPrefix(pod.Name, contName) || pod.Name == contVMIName {
+			if strings.HasPrefix(pod.Name, contName) || strings.HasPrefix(pod.Name, contVMIName) {
 				encAppStatus.ScheduledOnThisNode = true
 				if pod.Status.Phase == corev1.PodRunning {
 					encAppStatus.StatusRunning = true
@@ -209,7 +209,7 @@ func getnodeNameAndUUID(ctx *zedkubeContext) error {
 			return err
 		}
 		enInfo := NodeInfo.(types.EdgeNodeInfo)
-		ctx.nodeName = enInfo.DeviceName
+		ctx.nodeName = strings.ToLower(enInfo.DeviceName)
 		ctx.nodeuuid = enInfo.DeviceID.String()
 	}
 	return nil

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -10,9 +10,11 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	// "github.com/lf-edge/eve/pkg/newlog/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-amd64/src/strings"
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -898,7 +900,7 @@ func handleEdgeNodeInfoImpl(ctxArg interface{}, key string,
 		return
 	}
 
-	ctxPtr.nodeName = nodeInfo.DeviceName
+	ctxPtr.nodeName = strings.ToLower(nodeInfo.DeviceName)
 	ctxPtr.nodeuuid = nodeInfo.DeviceID.String()
 
 	//Re-enable local node


### PR DESCRIPTION
Also check for hasprefix for the contVMIname also.

With this fix both VMs and Pods are showing correct status in the UI.