### PR TITLE
Create volumemgr/DiskMetric for kubevirt PVCs

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlenodedrain.go
+++ b/pkg/pillar/cmd/baseosmgr/handlenodedrain.go
@@ -96,6 +96,9 @@ func initNodeDrainPubSub(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 // shouldDeferForNodeDrain will return true if this BaseOsStatus update will be handled later
 func shouldDeferForNodeDrain(ctx *baseOsMgrContext, id string, config *types.BaseOsConfig, status *types.BaseOsStatus) bool {
 	drainStatus := kubeapi.GetNodeDrainStatus(ctx.subNodeDrainStatus)
+	if drainStatus.Status == kubeapi.NOTSUPPORTED {
+		return false
+	}
 	if drainStatus.Status == kubeapi.UNKNOWN {
 		log.Error("shouldDeferForNodeDrain EARLY boot request, zedkube not up yet")
 		return false

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -123,6 +123,7 @@ func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{})
 		case <-diskMetricTicker.C:
 			start := time.Now()
 			createOrUpdateDiskMetrics(ctx, wdName)
+			createOrUpdatePvcDiskMetrics(ctx, wdName)
 			generateAndPublishVolumeMgrStatus(ctx)
 			ctx.ps.CheckMaxTimeTopic(wdName, "createOrUpdateDiskMetrics", start,
 				warningTime, errorTime)

--- a/pkg/pillar/cmd/volumemgr/handlepvcdiskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlepvcdiskmetrics.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build kubevirt
+
+package volumemgr
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// createOrUpdatePvcDiskMetrics creates or updates metrics for all kubevirt PVCs
+// PVC mknod will match one of existing sdX devices, create copies for convenience
+func createOrUpdatePvcDiskMetrics(ctx *volumemgrContext, wdName string) {
+	log.Functionf("createOrUpdatePvcDiskMetrics")
+	var diskMetricList []*types.DiskMetric
+	startPubTime := time.Now()
+
+	sdMajMinToNameMap, _, _ := kubeapi.SCSI_GetMajMinMaps()
+	_, pvNameToMajMin, _ := kubeapi.Longhorn_GetMajorMinorMaps()
+	_, pvcToPvMap, _ := kubeapi.PvPvcMaps()
+
+	kubeapi.CleanupUnmountedDiskMetrics(ctx.pubDiskMetric, pvcToPvMap)
+
+	for pvcName, pvName := range pvcToPvMap {
+		// pv-name will be of format "pvc-<uuid>"
+		// pvc-name will be of format "<uuid>-pvc-0"
+		// pvc-name uuid prefix will show in VolumeStatus
+		// full pvc-name will be in VolumeStatus.FileLocation
+
+		if pvName == "" {
+			continue
+		}
+
+		pvMajMinStr, ok := pvNameToMajMin[pvName]
+		if !ok {
+			continue
+		}
+
+		sdName, ok := sdMajMinToNameMap[pvMajMinStr]
+		if !ok {
+			continue
+		}
+
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
+
+		var metric *types.DiskMetric
+		metric = lookupDiskMetric(ctx, sdName)
+		if metric == nil {
+			continue
+		}
+
+		pvcMetric := lookupDiskMetric(ctx, pvcName)
+		if pvcMetric == nil {
+			pvcMetric = &types.DiskMetric{DiskPath: pvcName, IsDir: false}
+		}
+		pvcMetric.ReadBytes = metric.ReadBytes
+		pvcMetric.WriteBytes = metric.WriteBytes
+		pvcMetric.ReadCount = metric.ReadCount
+		pvcMetric.WriteCount = metric.WriteCount
+		pvcMetric.TotalBytes = metric.TotalBytes
+		pvcMetric.UsedBytes = metric.UsedBytes
+		pvcMetric.FreeBytes = metric.FreeBytes
+		pvcMetric.IsDir = false
+		diskMetricList = append(diskMetricList, pvcMetric)
+	}
+
+	log.Tracef("createOrUpdatePvcDiskMetrics: elapsed sec %v", time.Since(startPubTime).Seconds())
+
+	publishDiskMetrics(ctx, diskMetricList...)
+}

--- a/pkg/pillar/cmd/volumemgr/nokube.go
+++ b/pkg/pillar/cmd/volumemgr/nokube.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !kubevirt
+
+package volumemgr
+
+// createOrUpdatePvcDiskMetrics has no work in non kubevirt builds
+func createOrUpdatePvcDiskMetrics(*volumemgrContext, string) {
+	return
+}

--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -30,7 +30,7 @@ func GetPVCList(*base.LogObject) ([]string, error) {
 }
 
 // RequestNodeDrain is a stub for non-kubevirt builds
-func RequestNodeDrain(pubsub.Publication) error {
+func RequestNodeDrain(pubsub.Publication, DrainRequester, string) error {
 	// Nothing to do here, just noop
 	return fmt.Errorf("nokube requested drain, should not get here")
 }

--- a/pkg/pillar/kubeapi/storageutils.go
+++ b/pkg/pillar/kubeapi/storageutils.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2024 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build kubevirt
+
+package kubeapi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// XXX current used module version has int32, latest has uint64
+func device_major(stat syscall.Stat_t) int32 {
+	return int32((stat.Rdev >> 8) & 0xfff)
+}
+func device_minor(stat syscall.Stat_t) int32 {
+	return int32((stat.Rdev & 0xff) | ((stat.Rdev >> 12) & 0xfff00))
+}
+func getMajorMinor(stat syscall.Stat_t) string {
+	major := device_major(stat)
+	minor := device_minor(stat)
+	return fmt.Sprintf("%d:%d", major, minor)
+}
+
+func Longhorn_PVCs_Exist() bool {
+	LonghornDevPath := "/dev/longhorn"
+	if _, err := os.Stat(LonghornDevPath); err != nil {
+		return false
+	}
+	return true
+}
+
+func isPvMountedOnThisNode(pv string) bool {
+	if _, err := os.Stat("/dev/longhorn/" + pv); err != nil {
+		return false
+	}
+	return true
+}
+func isBlockDeviceMountedOnThisNode(dev string) bool {
+	if _, err := os.Stat("/dev/" + dev); err != nil {
+		return false
+	}
+	return true
+}
+
+func CleanupUnmountedDiskMetrics(pubDiskMetric pubsub.Publication, pvcToPvMap map[string]string) {
+	existingMetrics := pubDiskMetric.GetAll()
+
+	for id := range existingMetrics {
+		if strings.HasPrefix(id, "pvc-") {
+			pvName, ok := pvcToPvMap[id]
+			if ok {
+				if !isPvMountedOnThisNode(pvName) {
+					pubDiskMetric.Unpublish(id)
+				}
+			}
+		} else {
+			if !isBlockDeviceMountedOnThisNode(id) {
+				pubDiskMetric.Unpublish(id)
+			}
+		}
+	}
+}
+
+// Longhorn volume devices don't show up in /proc/diskstats
+// as their /dev/longhorn/<pv-name> path, only as the sdX path.
+// Its up to us to match them via their major:minor nexus
+// first map - maj:min -> kube-pv-name/lh-volume-name
+// second map - kube-pv-name/lh-volume-name -> maj:min
+func Longhorn_GetMajorMinorMaps() (map[string]string, map[string]string, error) {
+	lhMajMinToNameMap := make(map[string]string) // maj:min -> kube-pv-name/lh-volume-name
+	lhNameToMajMinMap := make(map[string]string) // kube-pv-name/lh-volume-name -> maj:min
+
+	LonghornDevPath := "/dev/longhorn"
+	if _, err := os.Stat(LonghornDevPath); err != nil {
+		return lhMajMinToNameMap, lhNameToMajMinMap, fmt.Errorf("longhorn dev path missing")
+	}
+
+	lhPvcList, err := os.ReadDir(LonghornDevPath)
+	if err != nil {
+		return lhMajMinToNameMap, lhNameToMajMinMap, fmt.Errorf("unable to read longhorn devs")
+	}
+
+	// build two maps:
+	// sdX -> major:minor
+	// major:minor -> lhpath
+	for _, lhDirEnt := range lhPvcList {
+		// get the lh device major:minor nexus
+		var lhStat syscall.Stat_t
+		err := syscall.Stat(LonghornDevPath+"/"+lhDirEnt.Name(), &lhStat)
+
+		if err != nil {
+			continue
+		}
+		majMinKey := getMajorMinor(lhStat)
+		lhMajMinToNameMap[majMinKey] = lhDirEnt.Name()
+		lhNameToMajMinMap[lhDirEnt.Name()] = majMinKey
+
+	}
+	return lhMajMinToNameMap, lhNameToMajMinMap, nil
+}
+
+// First map: maj:min -> sdX
+// Second map: sdX -> maj:min
+func SCSI_GetMajMinMaps() (map[string]string, map[string]string, error) {
+	sdMajMinToNameMap := make(map[string]string) // maj:min -> sdX
+	sdNameToMajMinMap := make(map[string]string) // sdX -> maj:min
+
+	blockDevs, err := os.ReadDir("/sys/class/block/")
+	if err != nil {
+		return sdMajMinToNameMap, sdNameToMajMinMap, fmt.Errorf("unable to read sd devs")
+	}
+
+	for _, devEnt := range blockDevs {
+		if !strings.HasPrefix(devEnt.Name(), "sd") {
+			continue
+		}
+
+		var blockStat syscall.Stat_t
+		err := syscall.Stat("/dev/"+devEnt.Name(), &blockStat)
+		if err != nil {
+			continue
+		}
+		majMinVal := getMajorMinor(blockStat)
+		sdMajMinToNameMap[majMinVal] = devEnt.Name()
+		sdNameToMajMinMap[devEnt.Name()] = majMinVal
+	}
+	return sdMajMinToNameMap, sdNameToMajMinMap, nil
+}
+
+// return two maps of pv-name/longhorn-name -> pvc-name
+// and pvc-name -> pv-name/longhorn-name
+func PvPvcMaps() (map[string]string, map[string]string, error) {
+	pvsMap := make(map[string]string)
+	pvcsMap := make(map[string]string)
+
+	clientset, err := GetClientSet()
+	if err != nil {
+		return pvsMap, pvcsMap, fmt.Errorf("PvToPvc_Map: can't get clientset %v", err)
+	}
+
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return pvsMap, pvcsMap, fmt.Errorf("get pvcs:%v", err)
+	}
+	for _, pvc := range pvcs.Items {
+		pvsMap[pvc.Spec.VolumeName] = pvc.ObjectMeta.Name
+		pvcsMap[pvc.ObjectMeta.Name] = pvc.Spec.VolumeName
+	}
+	return pvsMap, pvcsMap, nil
+}


### PR DESCRIPTION
Lookup sd block device major:minor
Used to lookup pv dev and then pvc name.

Fill three maps with the device relationships
at the beginning of the DiskMetric creation
loop to keep this lightweight.
For each createOrUpdatePvcDiskMetrics():
- one kubernetes api pvc list
- one syscall.stat per /dev/sdX device
- one syscall.stat per /dev/longhorn/<pv> device

Skip attempting to match volumestatus to zvol
	on kubevirt images.

Fix: avoid error log on single node kubevirt
	image when updating baseosmgr