### PR TITLE
kubevirt: add descheduler for rebalancing

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -53,6 +53,10 @@ COPY longhorn-generate-support-bundle.sh /usr/bin/
 COPY nsmounter /usr/bin/
 COPY etcd-io-perf-snapshot.sh /usr/bin/
 
+# descehduler
+COPY descheduler-job.yaml /etc/
+COPY descheduler-policy-configmap.yaml /etc/
+
 # Containerd config
 RUN mkdir -p /etc/containerd
 COPY config-k3s.toml /etc/containerd/

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1057,7 +1057,20 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 fi
         fi
 
-        if [ -f /var/lib/kubevirt_initialized ] && [ -f /var/lib/longhorn_initialized ]; then
+        #
+        # Descheduler
+        #
+        if [ ! -f /var/lib/descheduler_initialized ]; then
+                wait_for_item "descheduler"
+                logmsg "Installing Descheduler"
+                
+                DESCHEDULER_VERSION="v0.29.0"
+                kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/descheduler/${DESCHEDULER_VERSION}/kubernetes/base/rbac.yaml
+                kubectl apply -f /etc/descheduler-policy-configmap.yaml
+                touch /var/lib/descheduler_initialized
+        fi
+
+        if [ -f /var/lib/kubevirt_initialized ] && [ -f /var/lib/longhorn_initialized ] && [ -f /var/lib/descheduler_initialized ]; then
                 logmsg "All components initialized"
                 touch /var/lib/node-labels-initialized
                 touch /var/lib/all_components_initialized
@@ -1138,6 +1151,7 @@ fi
         check_and_remove_excessive_k3s_logs
         check_and_run_vnc
         Update_CheckClusterComponents
+        Update_RunDescheduler
         wait_for_item "wait"
         sleep 15
 done

--- a/pkg/kube/cluster-update.sh
+++ b/pkg/kube/cluster-update.sh
@@ -141,6 +141,23 @@ Update_CheckClusterComponents() {
     wait_for_item "update_cluster_post"
 }
 
+Update_RunDescheduler() {
+    # Don't run unless it has been installed
+    if [ ! -f /var/lib/descheduler_initialized ]; then
+        return
+    fi
+    # Only run once per boot
+    if [ -f /tmp/descheduler-ran ]; then
+        return
+    fi
+    # Job lives persistently in cluster, cleanup after old runs
+    if kubectl -n kube-system get job/descheduler-job; then
+        kubectl -n kube-system delete job/descheduler-job
+    fi
+    kubectl apply -f /etc/descheduler-job.yaml
+    touch /tmp/descheduler-ran
+}
+
 update_isClusterReady() {
     if ! kubectl cluster-info; then
         return 1

--- a/pkg/kube/descheduler-job.yaml
+++ b/pkg/kube/descheduler-job.yaml
@@ -1,0 +1,54 @@
+---
+# from: https://raw.githubusercontent.com/kubernetes-sigs/descheduler/${DESCHEDULER_VERSION}/kubernetes/job/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: descheduler-job
+  namespace: kube-system
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: descheduler-pod
+    spec:
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: descheduler
+          image: registry.k8s.io/descheduler/descheduler:v0.29.0
+          volumeMounts:
+            - mountPath: /policy-dir
+              name: policy-volume
+          command:
+            - "/bin/descheduler"
+          args:
+            - "--policy-config-file"
+            - "/policy-dir/policy.yaml"
+            - "--v"
+            - "3"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "256Mi"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10258
+              scheme: HTTPS
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+      restartPolicy: "Never"
+      serviceAccountName: descheduler-sa
+      volumes:
+        - name: policy-volume
+          configMap:
+            name: descheduler-policy-configmap

--- a/pkg/kube/descheduler-policy-configmap.yaml
+++ b/pkg/kube/descheduler-policy-configmap.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: descheduler-policy-configmap
+  namespace: kube-system
+data:
+  policy.yaml: |
+    apiVersion: "descheduler/v1alpha2"
+    kind: "DeschedulerPolicy"
+    profiles:
+      - name: ProfileName
+        pluginConfig:
+        - name: "RemovePodsViolatingNodeAffinity"
+          args:
+            namespaces:
+              include:
+              - "eve-kube-app"
+            nodeAffinityType:
+            - "preferredDuringSchedulingIgnoredDuringExecution"
+        plugins:
+          deschedule:
+            enabled:
+              - "RemovePodsViolatingNodeAffinity"

--- a/pkg/pillar/cmd/zedagent/handlenodedrain.go
+++ b/pkg/pillar/cmd/zedagent/handlenodedrain.go
@@ -19,7 +19,8 @@ func handleNodeDrainStatusImpl(ctxArg interface{}, key string,
 	configArg interface{}, oldConfigArg interface{}) {
 	newStatus, ok := configArg.(kubeapi.NodeDrainStatus)
 	if !ok {
-		log.Fatalf("handleNodeDrainStatusImpl invalid type in configArg: %v", configArg)
+		log.Errorf("handleNodeDrainStatusImpl invalid type in configArg: %v", configArg)
+		return
 	}
 
 	if newStatus.RequestedBy != kubeapi.DEVICEOP {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -3016,7 +3016,7 @@ func scheduleDeviceOperation(getconfigCtx *getconfigContext, opsCmd *zconfig.Dev
 	case kubeapi.NOTSUPPORTED:
 		log.Function("scheduleDeviceOperation drain not supported, skipping")
 	case kubeapi.NOTREQUESTED:
-		err := kubeapi.RequestNodeDrain(ctx.pubNodeDrainRequest, kubeapi.DEVICEOP)
+		err := kubeapi.RequestNodeDrain(ctx.pubNodeDrainRequest, kubeapi.DEVICEOP, op.String())
 		if err != nil {
 			log.Errorf("scheduleDeviceOperation: can't request node drain: %v", err)
 			return *prevReturn

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -2081,11 +2081,13 @@ func handleClusterUpdateStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}, oldStatusArg interface{}) {
 	ctx, ok := ctxArg.(*zedagentContext)
 	if !ok {
-		log.Fatalf("handleClusterUpdateStatusImpl invalid type in ctxArg: %v", ctxArg)
+		log.Errorf("handleClusterUpdateStatusImpl invalid type in ctxArg: %v", ctxArg)
+		return
 	}
 	req, ok := statusArg.(kubeapi.KubeClusterUpdateStatus)
 	if !ok {
-		log.Fatalf("handleClusterUpdateStatusImpl invalid type in configArg: %v", statusArg)
+		log.Errorf("handleClusterUpdateStatusImpl invalid type in configArg: %v", statusArg)
+		return
 	}
 	log.Noticef("handleClusterUpdateStatusImpl key:%s obj:%v", key, req)
 

--- a/pkg/pillar/cmd/zedkube/handlenodedrain.go
+++ b/pkg/pillar/cmd/zedkube/handlenodedrain.go
@@ -67,11 +67,11 @@ func handleNodeDrainRequestImpl(ctxArg interface{}, key string,
 	configArg interface{}, oldConfigArg interface{}) {
 	ctx, ok := ctxArg.(*zedkubeContext)
 	if !ok {
-		log.Fatalf("handleNodeDrainRequestImpl invalid type in ctxArg: %v", ctxArg)
+		log.Errorf("handleNodeDrainRequestImpl invalid type in ctxArg: %v", ctxArg)
 	}
 	req, ok := configArg.(kubeapi.NodeDrainRequest)
 	if !ok {
-		log.Fatalf("handleNodeDrainRequestImpl invalid type in configArg: %v", configArg)
+		log.Errorf("handleNodeDrainRequestImpl invalid type in configArg: %v", configArg)
 	}
 	ccList := ctx.subEdgeNodeClusterConfig.GetAll()
 	if len(ccList) == 0 {

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -7,6 +7,7 @@ package zedkube
 
 import (
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -101,6 +102,8 @@ type zedkubeContext struct {
 	pubServerCertFile        string
 	pubServerKeyFile         string
 	notifyPeerCount          int
+	// Primarily to block 'uncordon' after running it once at bootup
+	onBootUncordonCheckComplete bool
 }
 
 func inlineUsage() int {
@@ -533,18 +536,39 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	zedkubeCtx.subEdgeNodeClusterConfig = subEdgeNodeClusterConfig
 	subEdgeNodeClusterConfig.Activate()
 
+	// XXX hack for now
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Errorf("zedkube run: can't get hostname %v", err)
+	}
+	zedkubeCtx.nodeuuid = hostname
+
+	zedkubeCtx.config, err = kubeapi.GetKubeConfig()
+	if err != nil {
+		log.Errorf("zedkube: GetKubeConfig %v", err)
+	} else {
+		log.Noticef("zedkube: running")
+	}
+
 	// Look for edge node info
 	subEdgeNodeInfo, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   types.EdgeNodeInfo{},
-		Persistent:  true,
-		Activate:    true,
+		AgentName:     "zedagent",
+		MyAgentName:   agentName,
+		TopicImpl:     types.EdgeNodeInfo{},
+		Persistent:    true,
+		Activate:      false,
+		Ctx:           &zedkubeCtx,
+		CreateHandler: handleEdgeNodeInfoCreate,
+		ModifyHandler: handleEdgeNodeInfoModify,
+		DeleteHandler: handleEdgeNodeInfoDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 	zedkubeCtx.subEdgeNodeInfo = subEdgeNodeInfo
+	subEdgeNodeInfo.Activate()
 
 	// subscribe to zedagent status events, for controller connection status
 	subZedAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -570,6 +594,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		publishNodeDrainStatus(&zedkubeCtx, kubeapi.NOTREQUESTED)
 	}
 
+	zedkubeCtx.pubResendTimer = time.NewTimer(60 * time.Second)
+	zedkubeCtx.pubResendTimer.Stop()
+
+	// This will wait for kubernetes, longhorn, etc. to be ready
 	err = kubeapi.WaitForKubernetes(agentName, ps, stillRunning,
 		// Make sure we keep ClusterIPIsReady up to date while we wait
 		// for Kubernetes to come up.
@@ -578,30 +606,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	if err != nil {
 		log.Errorf("zedkube: WaitForKubenetes %v", err)
 	}
-	zedkubeCtx.config, err = kubeapi.GetKubeConfig()
-	if err != nil {
-		log.Errorf("zedkube: GetKubeConfig %v", err)
-	} else {
-		log.Noticef("zedkube: running")
-	}
-
-	zedkubeCtx.pubResendTimer = time.NewTimer(60 * time.Second)
-	zedkubeCtx.pubResendTimer.Stop()
-
-	//Re-enable local node
-	log.Noticef("zedkube re-enable-node/uncordon+")
-	cordoned, err := isNodeCordoned(&zedkubeCtx)
-	if err != nil {
-		log.Errorf("zedkube can't read local node cordon state, err:%v", err)
-	} else {
-		log.Noticef("zedkube isNodeCordoned cordoned:%v", cordoned)
-		if cordoned {
-			if err := cordonNode(&zedkubeCtx, false); err != nil {
-				log.Errorf("zedkube Unable to uncordon local node: %v", err)
-			}
-		}
-	}
-	log.Noticef("zedkube re-enable-node/uncordon-")
 
 	// notify peer nodes we are up, if there is any pubs, resend them
 	if zedkubeCtx.clusterPubSubStarted {
@@ -609,6 +613,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 
 	appLogTimer := time.NewTimer(logcollectInterval * time.Second)
+
+	log.Notice("zedkube online")
 
 	for {
 		select {
@@ -872,4 +878,83 @@ func (s *ReceiveMap) Find(key string) bool {
 	defer s.mu.Unlock()
 	_, ok := s.v[key]
 	return ok
+}
+
+func handleEdgeNodeInfoCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleEdgeNodeInfoImpl(ctxArg, key, statusArg)
+}
+
+func handleEdgeNodeInfoModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleEdgeNodeInfoImpl(ctxArg, key, statusArg)
+}
+
+func handleEdgeNodeInfoImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	ctxPtr := ctxArg.(*zedkubeContext)
+	nodeInfo := statusArg.(types.EdgeNodeInfo)
+	if err := getnodeNameAndUUID(ctxPtr); err != nil {
+		log.Errorf("handleEdgeNodeInfoImpl: getnodeNameAndUUID failed: %v", err)
+		return
+	}
+
+	ctxPtr.nodeName = nodeInfo.DeviceName
+	ctxPtr.nodeuuid = nodeInfo.DeviceID.String()
+
+	//Re-enable local node
+	if !ctxPtr.onBootUncordonCheckComplete {
+		go nodeOnBootHealthStatusWatcher(ctxPtr)
+	}
+}
+
+func handleEdgeNodeInfoDelete(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	// do nothing?
+	log.Functionf("handleEdgeNodeInfoDelete(%s) done", key)
+}
+
+// It may be a while until the node is ready to be uncordoned
+// so we'll keep trying until it is
+func nodeOnBootHealthStatusWatcher(ctx *zedkubeContext) {
+	// Assume we're cordoned until we know otherwise
+	cordoned := true
+
+	// Loop until it is uncordoned once to allow for later
+	// cordon operations to be successful
+	for cordoned {
+		time.Sleep(15 * time.Second)
+
+		// Get the local kubernetes node health status
+		node, err := getLocalNode(ctx.nodeuuid)
+		if node == nil || err != nil {
+			continue
+		}
+
+		// Is the node is ready?
+		var ready bool = false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == "Ready" && condition.Status == "True" {
+				ready = true
+			}
+		}
+		if !ready {
+			continue
+		}
+
+		cordoned, err = isNodeCordoned(ctx.nodeuuid)
+		if err != nil {
+			log.Errorf("zedkube can't read local node cordon state, err:%v", err)
+			continue
+		}
+
+		if !cordoned {
+			// Block this from running again this boot.
+			ctx.onBootUncordonCheckComplete = true
+		}
+
+		if err = cordonNode(ctx.nodeuuid, false); err != nil {
+			log.Errorf("zedkube Unable to uncordon local node: %v", err)
+		}
+	}
 }

--- a/pkg/pillar/docs/zedkube.md
+++ b/pkg/pillar/docs/zedkube.md
@@ -104,10 +104,13 @@ The current node drain progress is available from the global NodeDrainStatus obj
 NodeDrainStatus can be forced by writing the object (in pillar svc container fs) to: /tmp/force-NodeDrainStatus-global.json
 
 eg. to force disable drain:
-echo '{"Status":1,"RequestedBy":1}' > /tmp/force-NodeDrainStatus-global.json
+echo '{"Status":1,"RequestedBy":1}' > /persist/force-NodeDrainStatus-global.json
 
 eg. to force deviceop drain complete:
-echo '{"Status":9,"RequestedBy":2}' > /tmp/force-NodeDrainStatus-global.json
+echo '{"Status":9,"RequestedBy":2}' > /persist/force-NodeDrainStatus-global.json
+
+eg. to force baseosmgr drain complete:
+echo '{"Status":9,"RequestedBy":3}' > /persist/force-NodeDrainStatus-global.json
 
 "Cannot evict pod as it would violate the pod's disruption budget":
 If NodeDrainStatus can get stuck if attempting to drain a node running a pod where the pod has an 

--- a/pkg/pillar/kubeapi/kubetypes.go
+++ b/pkg/pillar/kubeapi/kubetypes.go
@@ -37,6 +37,7 @@ type NodeDrainRequest struct {
 	Hostname    string
 	RequestedAt time.Time
 	RequestedBy DrainRequester
+	Context     string
 }
 
 // NodeDrainStatus is a response to NodeDrainRequest

--- a/pkg/pillar/kubeapi/nodedrain.go
+++ b/pkg/pillar/kubeapi/nodedrain.go
@@ -15,7 +15,7 @@ import (
 )
 
 // RequestNodeDrain generates the NodeDrainRequest object and publishes it
-func RequestNodeDrain(pubNodeDrainRequest pubsub.Publication, requester DrainRequester) error {
+func RequestNodeDrain(pubNodeDrainRequest pubsub.Publication, requester DrainRequester, context string) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return fmt.Errorf("RequestNodeDrain: can't get hostname %v", err)
@@ -24,6 +24,7 @@ func RequestNodeDrain(pubNodeDrainRequest pubsub.Publication, requester DrainReq
 		Hostname:    hostname,
 		RequestedAt: time.Now(),
 		RequestedBy: requester,
+		Context:     context,
 	}
 	err = pubNodeDrainRequest.Publish("global", drainReq)
 	if err != nil {


### PR DESCRIPTION
Descheduler follows user defined policy to select pods and evict them to reach certain goals such as node utilization, re-scheduling, node failure
and add operations.

Fixes:
- reorganize zedkube startup to handle nodeuuid/nodename set inside pubsub handler EdgeNodeInfo to always overwrite whatever os.Hostname gave us before.
- Fix cordon detection
- Add new option to detect a consistent/persistent kube api outage and allow bypass of drain.  Next commit will make this opt-in via a config-property instead.
- Allow followon baseos updates to re-request drain after a previous drain failure.
- Move uncordon to a goroutine which waits for EdgeNodeInfo and then progressively checks for api access, node ready, then checks cordon state. Checked at bootup once.

Signed-off-by: Andrew Durbin <andrewd@zededa.com>
(cherry picked from commit 01510d8a8105cfe5d6cf8a724b81e3d9e989f985)