### PR TITLE
Delay Descheduler until local node is Ready

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -965,7 +965,7 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         # instead of waiting forever
         start_time=$(date +%s)
         while [ $(($(date +%s) - start_time)) -lt 120 ]; do
-            node_count_ready=$(kubectl get node | grep -w $HOSTNAME | grep -w Ready | wc -l)
+            node_count_ready=$(kubectl get "node/${HOSTNAME}" | grep -cw Ready )
             if [ $node_count_ready -ne 1 ]; then
                 sleep 10
                 continue
@@ -1086,7 +1086,7 @@ else
         if ! check_start_k3s; then
                 start_time=$(date +%s)
                 while [ $(($(date +%s) - start_time)) -lt 120 ]; do
-                    node_count_ready=$(kubectl get node | grep -w $HOSTNAME | grep -w Ready | wc -l)
+                    node_count_ready=$(kubectl get "node/${HOSTNAME}" | grep -cw Ready )
                     if [ $node_count_ready -ne 1 ]; then
                         sleep 10
                         pgrep -f "k3s server" > /dev/null 2>&1

--- a/pkg/kube/cluster-update.sh
+++ b/pkg/kube/cluster-update.sh
@@ -3,6 +3,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 K3S_VERSION=v1.28.5+k3s1
+EdgeNodeInfoPath="/persist/status/zedagent/EdgeNodeInfo/global.json"
 
 #
 # Handle any migrations needed due to updated cluster-init.sh
@@ -148,6 +149,20 @@ Update_RunDescheduler() {
     fi
     # Only run once per boot
     if [ -f /tmp/descheduler-ran ]; then
+        return
+    fi
+
+    if [ ! -f $EdgeNodeInfoPath ]; then
+        return
+    fi
+    # is api ready
+    if ! update_isClusterReady; then
+        return
+    fi
+    # node ready and allowing scheduling
+    node=$(jq -r '.DeviceName' < $EdgeNodeInfoPath | tr -d '\n' | tr '[:upper:]' '[:lower:]')
+    node_count_ready=$(kubectl get "node/${node}" | grep -v SchedulingDisabled | grep -cw Ready )
+    if [ "$node_count_ready" -ne 1 ]; then
         return
     fi
     # Job lives persistently in cluster, cleanup after old runs


### PR DESCRIPTION
Also fix a pattern found in a few spots where there was both an unnecessary 'grep' and 'wc -l'.
Instead move the node name into the get node/<name> and move the 'wc -l' into the grep with '-c'

Signed-off-by: Andrew Durbin <andrewd@zededa.com>
(cherry picked from commit c2df5ec3e7dfc1425575086e8bec9fdaabdbd4aa)