### PR TITLE
Allow kubectl get node to have OS-IMAGE feild display EVE release

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -808,6 +808,21 @@ restore_var_lib() {
   fi
 }
 
+# get the OS-IMAGE name from the /run/eve-release
+get_eve_os_release() {
+        # Wait for /run/eve-release to appear
+        while [ ! -f /run/eve-release ]; do
+                sleep 1
+        done
+
+        # Read the original name from /run/eve-release
+        eve_image_name=$(cat /run/eve-release)
+
+        logmsg "EVE Release: $eve_image_name, write to /etc/os-release"
+        # Write the short name to /etc/os-release
+        echo "PRETTY_NAME=\"$eve_image_name\"" > /etc/os-release
+}
+
 # provision the config.yaml and bootstrap-config.yaml for cluster node, passing $1 as k3s needs initailizing
 provision_cluster_config_file() {
 # prepare the config.yaml and bootstrap-config.yaml on node
@@ -952,6 +967,9 @@ else # a restart case, found all_components_initialized
     fi
   fi
 fi
+
+# use part of the /run/eve-release to get the OS-IMAGE string
+get_eve_os_release
 
 #Forever loop every 15 secs
 while true;


### PR DESCRIPTION
- the /run/eve-release string is used partially to be display in kubernetes, this is useful in particular with clustering with multiple nodes

```
☁  ~  k get node -o wide
NAME          STATUS   ROLES                       AGE     VERSION        INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                   KERNEL-VERSION                  CONTAINER-RUNTIME
plex1-7050m   Ready    control-plane,etcd,master   4d23h   v1.28.5+k3s1   10.244.244.1   <none>        poc-oct03-2024-02db99a6                    6.1.106-linuxkit-06a737b0f212   containerd://1.7.11-k3s2
plex2-7050m   Ready    control-plane,etcd,master   28h     v1.28.5+k3s1   10.244.244.2   <none>        Unknown                                    6.1.106-linuxkit-06a737b0f212   containerd://1.7.11-k3s2
plex3-7050m   Ready    control-plane,etcd,master   28h     v1.28.5+k3s1   10.244.244.3   <none>        poc-oct03-2024-02db99a6-2024-10-04.03.10   6.1.106-linuxkit-06a737b0f212   containerd://1.7.11-k3s2
```
