### PR TITLE
Remove kube container logs to be uploading to controller

### DIFF
--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -656,6 +656,11 @@ func getMemlogMsg(logChan chan inputEntry, panicFileChan chan []byte) {
 			pidStr = strconv.Itoa(logInfo.Pid)
 		}
 
+		// not to upload 'kube' container logs, one can find in /persist/kubelog for detail
+		if logInfo.Source == "kube" {
+			continue
+		}
+
 		entry := inputEntry{
 			source:    logInfo.Source,
 			content:   logInfo.Msg,


### PR DESCRIPTION
- if the memlogd sends source of 'kube' logs, drop them without uploading to the controller side.