### PR TITLE
Fix an issue of publishing empty EdgeNodeClusterStatus

### DIFF
--- a/pkg/pillar/cmd/zedkube/clusterstatus.go
+++ b/pkg/pillar/cmd/zedkube/clusterstatus.go
@@ -43,7 +43,12 @@ func applyDNS(ctx *zedkubeContext, dns types.DeviceNetworkStatus) {
 				stopClusterStatusServer(ctx)
 			}
 		}
-		publishKubeConfigStatus(ctx)
+		// NIM can publish network status due to cluster config
+		// removal, and we don't want to publish the dummy/empty
+		// cluster status in that case.
+		if ctx.clusterConfig.ClusterInterface != "" {
+			publishKubeConfigStatus(ctx)
+		}
 	}
 }
 


### PR DESCRIPTION
- when converting to from cluster mode. there can be a chance the NIM sents network-status changes, which could cause zedkube to publish an empty EdgeNodeClusterStatus, that will break the converting to single-node mode.