### PR TITLE
Extend event ttl to 24hr, dump in collect-info

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -356,6 +356,10 @@ collect_kube_info()
            echo "============"
            eve exec kube kubectl top pod -A --sum
            echo "============"
+           echo "kubectl get event -A"
+           echo "============"
+           eve exec kube kubectl get event -A
+           echo "============"
         } > "$DIR/kube-info"
     fi
 }

--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -13,3 +13,4 @@ etcd-expose-metrics: true
 container-runtime-endpoint: "/run/containerd-user/containerd.sock"
 disable-network-policy: true
 disable-cloud-controller: true
+event-ttl: "24h"


### PR DESCRIPTION
Default is 1hr which drops useful debug info.