### PR TITLE
Handle application delete operation in domainmgr

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1814,6 +1814,11 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 			log.Noticef("doActivateTail(%v) we are not DNiD, skip delete app", status.DomainName)
 			return
 		}
+
+		if ctx.hvTypeKube && !status.DomainConfigDeleted {
+			log.Noticef("doActivateTail(%v) DomainConfig exists, skip delete app", status.DomainName)
+			return
+		}
 		// Delete
 		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
@@ -1848,6 +1853,11 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 			log.Noticef("doActivateTail(%v) we are not DNiD, skip delete app", status.DomainName)
 			return
 		}
+		if ctx.hvTypeKube && !status.DomainConfigDeleted {
+			log.Noticef("doActivateTail(%v) DomainConfig exists, skip delete app", status.DomainName)
+			return
+		}
+
 		// Delete
 		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
@@ -1951,6 +1961,10 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 	if status.DomainId != 0 {
 		if !status.IsDNidNode {
 			log.Noticef("doInactivate(%v) we are not DNiD, skip delete app", status.DomainName)
+			return
+		}
+		if ctx.hvTypeKube && !status.DomainConfigDeleted {
+			log.Noticef("doInactivate(%v) DomainConfig exists, skip delete app", status.DomainName)
 			return
 		}
 
@@ -2521,6 +2535,8 @@ func handleDelete(ctx *domainContext, key string, status *types.DomainStatus) {
 		log.Noticef("handleDelete(%v) we are not DNiD, skip delete app", status.DomainName)
 		return
 	}
+	status.DomainConfigDeleted = true
+	log.Noticef("handleDelete(%v) DomainConfigDeleted", status.DomainName)
 
 	err := hyper.Task(status).Delete(status.DomainName)
 	if err != nil {

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -322,6 +322,10 @@ type DomainStatus struct {
 	VirtualTPM bool
 	// if this node is the DNiD of the App
 	IsDNidNode bool
+	// handle DomainConfig Delete
+	// For kubevirt Apps, there is no need to delete the domain from the
+	// kubernetes, unless the domain is removed from configuration.
+	DomainConfigDeleted bool
 	// the device name is used for kube node name
 	// Need to pass in from domainmgr to hypervisor context commands
 	NodeName string


### PR DESCRIPTION
- a new flag in DomainStatus, DomainConfigDeleted and that will be set only in the case of DomainConfig is removed. We'll not do domain delete from domainmgr to the kubernetes unless this flag is set. In kubernetes, the config is stored in database, there is no need to delete it due to status check failed