### PR TITLE
Set ClusterAppRunning to show the node failover destination of an app.

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1165,6 +1165,11 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			snapInfo.SnapErr = encodeErrorInfo(snap.Error)
 			ReportAppInfo.Snapshots = append(ReportAppInfo.Snapshots, snapInfo)
 		}
+
+		// For Clustered apps on HV=kubevirt, 'ClusterAppRunning' designates
+		// the app is running on the local node after some failover event.
+		ReportAppInfo.ClusterAppRunning = aiStatus.Activated
+
 	}
 
 	ReportInfo.InfoContent = new(info.ZInfoMsg_Ainfo)


### PR DESCRIPTION
Find the domainmgr/DomainStatus where .DomainName matches the AppInstanceStatus.DomainName. If this is found, set the .ClusterAppRunning flag to match DomainStatus.Activated.