### PR TITLE
Handle failover and volmgr changes

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -160,6 +160,13 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 			status.TotalSize = int64(actualSize)
 			status.CurrentSize = int64(actualSize)
 		}
+
+		// Fill the ReferenceName which will be used by domainmgr to launch native containers.
+		ctStatus := ctx.LookupContentTreeStatus(status.ContentID.String())
+
+		if ctStatus != nil {
+			status.ReferenceName = ctStatus.ReferenceID()
+		}
 		publishVolumeStatus(ctx, status)
 		updateVolumeRefStatus(ctx, status)
 		if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1057,6 +1057,7 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 
 	ReportAppInfo.AppID = uuid
 	ReportAppInfo.SystemApp = false
+	ReportAppInfo.ClusterAppRunning = false
 
 	if aiStatus != nil {
 		ReportAppInfo.AppVersion = aiStatus.UUIDandVersion.Version

--- a/pkg/pillar/cmd/zedmanager/handleclusterapp.go
+++ b/pkg/pillar/cmd/zedmanager/handleclusterapp.go
@@ -19,22 +19,37 @@ func handleENClusterAppStatusModify(ctxArg interface{}, key string, configArg in
 func handleENClusterAppStatusDelete(ctxArg interface{}, key string, configArg interface{}) {
 	log.Noticef("handleENClusterAppStatusDelete(%s)", key)
 	ctx := ctxArg.(*zedmanagerContext)
-	//status := configArg.(types.ENClusterAppStatus)
-	handleENClusterAppStatusImpl(ctx, key, nil)
+	status := configArg.(types.ENClusterAppStatus)
+	handleENClusterAppStatusImpl(ctx, key, &status)
 }
 
 func handleENClusterAppStatusImpl(ctx *zedmanagerContext, key string, status *types.ENClusterAppStatus) {
 
-	log.Noticef("handleENClusterAppStatusImpl(%s) for app-status %v", key, status)
-	pub := ctx.pubAppInstanceStatus
-	items := pub.GetAll()
-	for _, st := range items {
-		aiStatus := st.(types.AppInstanceStatus)
-		if aiStatus.UUIDandVersion.UUID.String() == key {
-			log.Noticef("handleENClusterAppStatusImpl(%s) found ai status, update", key)
+	aiStatus := lookupAppInstanceStatus(ctx, key)
+	log.Noticef("handleENClusterAppStatusImpl(%s) for app-status %v aiStatus %v", key, status, aiStatus)
 
+	if status.ScheduledOnThisNode {
+		if aiStatus == nil {
+			// This could happen if app failover to other node and failing back to this designated node.
+			// One scenario is node reboot. Kubernetes told us that app is scheduled on this node.
+			aiConfig := lookupAppInstanceConfig(ctx, key, false)
+			if aiConfig == nil {
+				log.Errorf("handleENClusterAppStatusImpl(%s) AppInstanceConfig missing for app", key)
+				return
+			}
+			handleCreateAppInstanceStatus(ctx, *aiConfig)
+		} else {
 			updateAIStatusUUID(ctx, aiStatus.UUIDandVersion.UUID.String())
-			break
 		}
+	} else { // not scheduled here.
+
+		// if aiStatus is not present, nothing to do
+		if aiStatus != nil {
+			// If I am not scheduled here, just unpublish the AIStatus.
+			// We probably had app running on this node earlier before failover.
+			unpublishAppInstanceStatus(ctx, aiStatus)
+		}
+
 	}
+
 }

--- a/pkg/pillar/types/clustertypes.go
+++ b/pkg/pillar/types/clustertypes.go
@@ -41,7 +41,6 @@ type ENClusterAppStatus struct {
 	IsDNSet             bool      // DesignatedNodeID is set for this node
 	ScheduledOnThisNode bool      // App is running on this device
 	StatusRunning       bool      // Status of the app in "Running" state
-	IsVolumeDetached    bool      // Are volumes detached after failover ?
 }
 
 func (config EdgeNodeClusterConfig) Key() string {


### PR DESCRIPTION
This is rework of PR https://github.com/naiming-zededa/eve/pull/390/

Retested everything.

With this commit only node that is running the app will publish the AppInstanceStatus.
If the app gets scheduled on a node AppInstanceStatus will be created and published.
If the app gets de-scheduled , unpublishAppInstanceStatus will be called.

zedkube will now publish first  ENCAppStatus only when app gets scheduled on the node and its a designated node id.