### PR TITLE
Fix some bugs found in testing

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -7,8 +7,6 @@ log: "/persist/kubelog/k3s.log"
 egress-selector-mode: "disabled"
 # Use longhorn storage
 disable: local-storage
-disable: traefik
-disable: servicelb 
 etcd-arg:
   - "quota-backend-bytes=8589934592"
 etcd-expose-metrics: true

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -318,10 +318,17 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 
 func createOrUpdateAppDiskMetrics(ctx *volumemgrContext, volumeStatus *types.VolumeStatus) error {
 	log.Functionf("createOrUpdateAppDiskMetrics(%s, %s)", volumeStatus.VolumeID, volumeStatus.FileLocation)
+
 	if volumeStatus.FileLocation == "" {
-		// Nothing we can do? XXX can we retrieve size from CAS?
-		return nil
+		if !ctx.hvTypeKube {
+			// Nothing we can do? XXX can we retrieve size from CAS?
+			return nil
+		} else {
+			// Kubevirt eve volumes have no location on /persist, they are PVCs
+			volumeStatus.FileLocation = volumeStatus.GetPVCName()
+		}
 	}
+
 	actualSize, maxSize, diskType, dirtyFlag, err := volumehandlers.GetVolumeHandler(log, ctx, volumeStatus).GetVolumeDetails()
 	if err != nil {
 		err = fmt.Errorf("createOrUpdateAppDiskMetrics(%s, %s): exception while getting volume size. %s",

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -394,7 +394,11 @@ func quantifyChanges(config types.VolumeConfig,
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
-	if config.MaxVolSize != status.MaxVolSize {
+
+	// Replicated volumes are special, they are not created on this node
+	// So the config might have size 0 and while generating we calculate the status.MaxVolSize.
+	// they may not match.
+	if config.MaxVolSize != status.MaxVolSize && !config.IsReplicated {
 		str := fmt.Sprintf("MaxVolSize changed from %d to %d for %s",
 			status.MaxVolSize, config.MaxVolSize, config.DisplayName)
 		log.Functionf(str)

--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -202,7 +202,7 @@ func checkAppsStatus(ctx *zedkubeContext) {
 		// 1) We just got appinstanceconfig and domainmgr did not get chance to start it yet, timing issue, zedkube checked first
 		// 2) We are checking after app failover to other node, either this node network failed and came back or this just got rebooted
 
-		if oldStatus == nil && !encAppStatus.ScheduledOnThisNode && encAppStatus.IsDNSet {
+		if oldStatus == nil && !encAppStatus.ScheduledOnThisNode && encAppStatus.IsDNSet && !foundPod {
 			log.Noticef("checkAppsStatus: app not yet scheduled on this node %v", encAppStatus)
 			continue
 		}


### PR DESCRIPTION
1) Add !foundpod to publish ENCAppstatus on designated node
2) If its a replicated PVC the maxvolsize in config and status may not match, so ignore it
3) FileLocation may not be set for PVC, since PVC is not present in /persist location, ignore that for kubevirt eve and publish app disk metrics.