### PR TITLE
We do not need to updateAIStatusUUID from handleENClusterAppStatusImpl

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handleclusterapp.go
+++ b/pkg/pillar/cmd/zedmanager/handleclusterapp.go
@@ -39,7 +39,9 @@ func handleENClusterAppStatusImpl(ctx *zedmanagerContext, key string, status *ty
 			}
 			handleCreateAppInstanceStatus(ctx, *aiConfig)
 		} else {
-			updateAIStatusUUID(ctx, aiStatus.UUIDandVersion.UUID.String())
+			// Nothing to do, we already have aiStatus
+			log.Functionf("handleENClusterAppStatusImpl(%s) for app-status %v aiStatus %v", key, status, aiStatus)
+			return
 		}
 	} else { // not scheduled here.
 


### PR DESCRIPTION
Remove  updateAIStatusUUID from handleENClusterAppStatusImpl(). We don't need that. If there is update required there is a normal eve code path which does that. 

So basically handleENClusterAppStatusImpl() is very simple.

If app scheduled on me {
 if no aiStatus {
     create and publish
 }
} else {
    // app not on me.
    if aiStatus {
      unpublishAppInstanceStatus()
    }
}


I tested multiple failovers, all seems to be good.