### PR TITLE
Ignore kube specific directories in /persist for DiskMetrics

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -274,6 +274,8 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 	var excludeDirs []string
 	excludeDirs = append(excludeDirs, types.ReportDirPaths...)
 	excludeDirs = append(excludeDirs, types.AppPersistPaths...)
+	excludeDirs = append(excludeDirs, types.KubeIgnorePaths...)
+
 	list, err := diskmetrics.FindLargeFiles(types.PersistDir, 1024*1024,
 		excludeDirs)
 	if err != nil {

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -42,6 +42,13 @@ var ReportDirPaths = []string{
 	PersistDir + "/eve-info",
 }
 
+// These should be ignored, the space occupied is already accounted in /persist
+// These will lead to too many json files for pubsub, which are not required.
+var KubeIgnorePaths = []string{
+	PersistDir + "/kube-save-var-lib",
+	PersistDir + "/kubelog",
+}
+
 // AppPersistPaths  Application-related files live here
 // XXX do we need to exclude the ContentTrees used for eve image update?
 // If so how do we tell them apart?


### PR DESCRIPTION
Ignore /persist/kubelog and /persist/kube-save-var-lib when generating disk metrics