### PR TITLE
Handle code review in main branch PR 4407

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -432,7 +432,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Parse any existing ConfigIntemValueMap but continue if there
 	// is none
 	waitEdgeNodeInfo := true
-	wtTime := time.Now()
 	for !domainCtx.GCComplete || (domainCtx.hvTypeKube && waitEdgeNodeInfo) {
 		log.Noticef("waiting for GCComplete")
 		select {
@@ -449,11 +448,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case <-stillRunning.C:
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
-		if time.Since(wtTime) > 5*time.Minute { // wait for max of 5 minutes
-			waitEdgeNodeInfo = false
-		}
 	}
 	log.Noticef("processed GCComplete")
+	err = domainCtx.retrieveDeviceNodeName()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if !domainCtx.setInitialUsbAccess {
 		log.Functionf("GCComplete but not setInitialUsbAccess => first boot")
@@ -1105,13 +1105,6 @@ func maybeRetryBoot(ctx *domainContext, status *types.DomainStatus) {
 		return
 	}
 
-	err := getnodeNameAndUUID(ctx)
-	if err != nil {
-		log.Errorf("maybeRetryBoot(%s) getnodeNameAndUUID failed: %s",
-			status.Key(), err)
-		return
-	}
-
 	if status.Activated && status.BootFailed {
 		log.Functionf("maybeRetryBoot(%s) clearing bootFailed since Activated",
 			status.Key())
@@ -1374,7 +1367,6 @@ func handleCreate(ctx *domainContext, key string, config *types.DomainConfig) {
 		State:          types.INSTALLED,
 		VmConfig:       config.VmConfig,
 		Service:        config.Service,
-		IsDNidNode:     config.IsDNidNode,
 	}
 
 	status.VmConfig.CPUs = ""
@@ -1583,13 +1575,6 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 
 	log.Functionf("doActivate(%v) for %s",
 		config.UUIDandVersion, config.DisplayName)
-
-	err := getnodeNameAndUUID(ctx)
-	if err != nil {
-		log.Errorf("doActivate(%s) getnodeNameAndUUID failed: %s",
-			status.Key(), err)
-		return
-	}
 
 	if ctx.cpuPinningSupported {
 		if err := assignCPUs(ctx, &config, status); err != nil {
@@ -1809,16 +1794,6 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		log.Errorf("domain start for %s: %s", status.DomainName, err)
 		status.SetErrorNow(err.Error())
 
-		// HvKube case
-		if !status.IsDNidNode {
-			log.Noticef("doActivateTail(%v) we are not DNiD, skip delete app", status.DomainName)
-			return
-		}
-
-		if ctx.hvTypeKube && !status.DomainConfigDeleted {
-			log.Noticef("doActivateTail(%v) DomainConfig exists, skip delete app", status.DomainName)
-			return
-		}
 		// Delete
 		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
@@ -1848,15 +1823,6 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		status.SetErrorNow(err.Error())
 		log.Errorf("doActivateTail(%v) failed for %s: %s",
 			status.UUIDandVersion, status.DisplayName, err)
-
-		if !status.IsDNidNode {
-			log.Noticef("doActivateTail(%v) we are not DNiD, skip delete app", status.DomainName)
-			return
-		}
-		if ctx.hvTypeKube && !status.DomainConfigDeleted {
-			log.Noticef("doActivateTail(%v) DomainConfig exists, skip delete app", status.DomainName)
-			return
-		}
 
 		// Delete
 		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
@@ -1959,15 +1925,6 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 	}
 
 	if status.DomainId != 0 {
-		if !status.IsDNidNode {
-			log.Noticef("doInactivate(%v) we are not DNiD, skip delete app", status.DomainName)
-			return
-		}
-		if ctx.hvTypeKube && !status.DomainConfigDeleted {
-			log.Noticef("doInactivate(%v) DomainConfig exists, skip delete app", status.DomainName)
-			return
-		}
-
 		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
 			log.Errorf("Failed to delete domain %s (%v)", status.DomainName, err)
 		} else {
@@ -2531,13 +2488,6 @@ func handleDelete(ctx *domainContext, key string, status *types.DomainStatus) {
 	// No point in publishing metrics any more
 	ctx.pubDomainMetric.Unpublish(status.Key())
 
-	if !status.IsDNidNode {
-		log.Noticef("handleDelete(%v) we are not DNiD, skip delete app", status.DomainName)
-		return
-	}
-	status.DomainConfigDeleted = true
-	log.Noticef("handleDelete(%v) DomainConfigDeleted", status.DomainName)
-
 	err := hyper.Task(status).Delete(status.DomainName)
 	if err != nil {
 		log.Errorln(err)
@@ -2585,10 +2535,6 @@ func DomainShutdown(status types.DomainStatus, force bool) error {
 	// Stop the domain
 	log.Functionf("Stopping domain - %s", status.DomainName)
 
-	if !status.IsDNidNode {
-		log.Noticef("DomainShutdown(%v) we are not DNiD, skip delete app", status.DomainName)
-		return nil
-	}
 	err = hyper.Task(&status).Stop(status.DomainName, force)
 
 	return err
@@ -3678,16 +3624,14 @@ func lookupCapabilities(ctx *domainContext) (*types.Capabilities, error) {
 	return &capabilities, nil
 }
 
-func getnodeNameAndUUID(ctx *domainContext) error {
-	if ctx.nodeName == "" {
-		NodeInfo, err := ctx.subEdgeNodeInfo.Get("global")
-		if err != nil {
-			log.Errorf("getnodeNameAndUUID: can't get edgeNodeInfo %v", err)
-			return err
-		}
-		enInfo := NodeInfo.(types.EdgeNodeInfo)
-		ctx.nodeName = strings.ToLower(enInfo.DeviceName)
-		log.Noticef("**getnodeNameAndUUID: devicename, NodeInfo %v", NodeInfo) // XXX
+func (ctx *domainContext) retrieveDeviceNodeName() error {
+	NodeInfo, err := ctx.subEdgeNodeInfo.Get("global")
+	if err != nil {
+		log.Errorf("retrieveDeviceNodeName: can't get edgeNodeInfo %v", err)
+		return err
 	}
+	enInfo := NodeInfo.(types.EdgeNodeInfo)
+	ctx.nodeName = strings.ToLower(enInfo.DeviceName)
+	log.Noticef("retrieveDeviceNodeName: devicename, NodeInfo %v", NodeInfo) // XXX
 	return nil
 }

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -3131,12 +3131,8 @@ func parseEdgeNodeClusterConfig(getconfigCtx *getconfigContext,
 		gcp := ctx.globalConfig
 		gcpEncCfg := gcp.GlobalValueString(types.ENClusterConfig)
 		if gcpEncCfg == "" {
-			pub := ctx.pubEdgeNodeClusterConfig
-			items := pub.GetAll()
-			if len(items) > 0 {
-				log.Functionf("parseEdgeNodeClusterConfig: Unpublishing EdgeNodeClusterConfig")
-				ctx.pubEdgeNodeClusterConfig.Unpublish("global")
-			}
+			log.Functionf("parseEdgeNodeClusterConfig: Unpublishing EdgeNodeClusterConfig")
+			ctx.pubEdgeNodeClusterConfig.Unpublish("global")
 		}
 		return
 	}
@@ -3148,6 +3144,10 @@ func parseEdgeNodeClusterConfig(getconfigCtx *getconfigContext,
 	ipNet.IP = ipAddr
 
 	joinServerIP := net.ParseIP(zcfgCluster.GetJoinServerIp())
+	if joinServerIP == nil {
+		log.Errorf("handleEdgeNodeConfigItem: parse JoinServerIP failed")
+		return
+	}
 	var isJoinNode bool
 	// deduce the bootstrap node status from clusterIPPrefix and joinServerIP
 	if ipAddr.Equal(joinServerIP) { // deduce the bootstrap node status from

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -49,6 +49,7 @@ const (
 	waitForPodCheckCounter = 5  // Check 5 times
 	waitForPodCheckTime    = 15 // Check every 15 seconds, don't wait for too long to cause watchdog
 	tolerateSec            = 30 // Pod/VMI reschedule delay after node unreachable seconds
+	unknownToHaltMinutes   = 5  // If VMI is unknown for 5 minutes, return halt state
 )
 
 type MetaDataType int
@@ -63,13 +64,14 @@ const (
 
 // VM instance meta data structure.
 type vmiMetaData struct {
-	repPod   *appsv1.ReplicaSet                   // Handle to the replicaSetof pod
-	repVMI   *v1.VirtualMachineInstanceReplicaSet // Handle to the replicaSet of VMI
-	domainID int                                  // DomainID understood by domainmgr in EVE
-	mtype    MetaDataType                         // switch on is ReplicaSet, Pod or is VMI
-	name     string                               // Display-Name(all lower case) + first 5 bytes of domainName
-	cputotal uint64                               // total CPU in NS so far
-	maxmem   uint32                               // total Max memory usage in bytes so far
+	repPod           *appsv1.ReplicaSet                   // Handle to the replicaSetof pod
+	repVMI           *v1.VirtualMachineInstanceReplicaSet // Handle to the replicaSet of VMI
+	domainID         int                                  // DomainID understood by domainmgr in EVE
+	mtype            MetaDataType                         // switch on is ReplicaSet, Pod or is VMI
+	name             string                               // Display-Name(all lower case) + first 5 bytes of domainName
+	cputotal         uint64                               // total CPU in NS so far
+	maxmem           uint32                               // total Max memory usage in bytes so far
+	startUnknownTime time.Time                            // time when the domain returned as unknown status
 }
 
 type kubevirtContext struct {
@@ -87,12 +89,13 @@ type kubevirtContext struct {
 var stateMap = map[string]types.SwState{
 	"Paused":     types.PAUSED,
 	"Running":    types.RUNNING,
-	"NonLocal":   types.RUNNING,
 	"shutdown":   types.HALTING,
 	"suspended":  types.PAUSED,
 	"Pending":    types.PENDING,
 	"Scheduling": types.SCHEDULING,
 	"Failed":     types.FAILED,
+	"Halting":    types.HALTING,
+	"Unknown":    types.UNKNOWN,
 }
 
 var excludedMetrics = map[string]struct{}{
@@ -516,7 +519,7 @@ func (ctx kubevirtContext) Start(domainName string) error {
 
 	// Start the Pod ReplicaSet
 	if vmis.mtype == IsMetaReplicaPod {
-		err := StartReplicaPodContiner(ctx, ctx.vmiList[domainName].repPod)
+		err := StartReplicaPodContiner(ctx, vmis)
 		return err
 	} else if vmis.mtype != IsMetaReplicaVMI {
 		return logError("Start domain %s wrong type", domainName)
@@ -554,7 +557,7 @@ func (ctx kubevirtContext) Start(domainName string) error {
 	}
 	logrus.Infof("Started Kubevirt domain replicaset %s, VMI replicaset %s", domainName, vmis.name)
 
-	err = waitForVMI(vmis.name, nodeName, true)
+	err = waitForVMI(vmis, nodeName, true)
 	if err != nil {
 		logrus.Errorf("couldn't start VMI %v", err)
 		return err
@@ -678,21 +681,18 @@ func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
 		return 0, types.HALTED, logError("info domain %s failed to get vmlist", domainName)
 	}
 	if vmis.mtype == IsMetaReplicaPod {
-		res, err = InfoReplicaSetContainer(ctx, vmis.name)
+		res, err = InfoReplicaSetContainer(ctx, vmis)
 	} else {
-		res, err = getVMIStatus(vmis.name, nodeName)
-	}
-	if err != nil {
-		return 0, types.BROKEN, logError("domain %s failed to get info: %v", domainName, err)
+		res, err = getVMIStatus(vmis, nodeName)
 	}
 
 	if effectiveDomainState, matched := stateMap[res]; !matched {
 		return 0, types.BROKEN, logError("domain %s reported to be in unexpected state %s", domainName, res)
 	} else {
-		if _, ok := ctx.vmiList[domainName]; !ok {
+		if _, ok := ctx.vmiList[domainName]; !ok { // domain is deleted
 			return 0, types.HALTED, logError("domain %s is deleted", domainName)
 		}
-		return ctx.vmiList[domainName].domainID, effectiveDomainState, nil
+		return ctx.vmiList[domainName].domainID, effectiveDomainState, err
 	}
 }
 
@@ -712,12 +712,12 @@ func (ctx kubevirtContext) Cleanup(domainName string) error {
 		return logError("cleanup domain %s failed to get vmlist", domainName)
 	}
 	if vmis.mtype == IsMetaReplicaPod {
-		_, err = InfoReplicaSetContainer(ctx, vmis.name)
+		_, err = InfoReplicaSetContainer(ctx, vmis)
 		if err == nil {
 			err = ctx.Delete(domainName)
 		}
 	} else if vmis.mtype == IsMetaReplicaVMI {
-		err = waitForVMI(vmis.name, nodeName, false)
+		err = waitForVMI(vmis, nodeName, false)
 	} else {
 		err = logError("cleanup domain %s wrong type", domainName)
 	}
@@ -744,8 +744,9 @@ func convertToKubernetesFormat(b int) string {
 	return fmt.Sprintf("%.1fYi", bf)
 }
 
-func getVMIStatus(repVmiName, nodeName string) (string, error) {
+func getVMIStatus(vmis *vmiMetaData, nodeName string) (string, error) {
 
+	repVmiName := vmis.name
 	kubeconfig, err := kubeapi.GetKubeConfig()
 	if err != nil {
 		return "", logError("couldn't get the Kube Config: %v", err)
@@ -760,14 +761,19 @@ func getVMIStatus(repVmiName, nodeName string) (string, error) {
 	// List VMIs with a label selector that matches the replicaset name
 	vmiList, err := virtClient.VirtualMachineInstance(kubeapi.EVEKubeNameSpace).List(context.Background(), &metav1.ListOptions{})
 	if err != nil {
-		return "", logError("getVMIStatus: domain %s failed to get VMI info %s", repVmiName, err)
+		retStatus, err2 := checkAndReturnStatus(vmis, true)
+		logError("getVMIStatus: domain %s failed to get VMI info %s, return %s", repVmiName, err, retStatus)
+		return retStatus, err2
 	}
 	if len(vmiList.Items) == 0 {
-		return "", logError("getVMIStatus: No VMI found with the given replicaset name %s", repVmiName)
+		retStatus, err2 := checkAndReturnStatus(vmis, true)
+		logError("getVMIStatus: No VMI found with the given replicaset name %s, return %s", repVmiName, retStatus)
+		return retStatus, err2
 	}
 
 	// Use the first VMI in the list
 	var foundNonlocal bool
+	var nonLocalStatus string
 	var targetVMI *v1.VirtualMachineInstance
 	for _, vmi := range vmiList.Items {
 		if vmi.Status.NodeName == nodeName {
@@ -778,21 +784,27 @@ func getVMIStatus(repVmiName, nodeName string) (string, error) {
 		} else {
 			if vmi.GenerateName == repVmiName {
 				foundNonlocal = true
+				nonLocalStatus = fmt.Sprintf("%v", vmi.Status.Phase)
 			}
 		}
 	}
 	if targetVMI == nil {
 		if foundNonlocal {
-			return "NonLocal", nil
+			_, _ = checkAndReturnStatus(vmis, false) // reset the unknown timestamp
+			return nonLocalStatus, nil
 		}
-		return "", logError("getVMIStatus: No VMI %s found with the given nodeName %s", repVmiName, nodeName)
+		retStatus, err2 := checkAndReturnStatus(vmis, true)
+		logError("getVMIStatus: No VMI %s found with the given nodeName %s, return %s", repVmiName, nodeName, retStatus)
+		return retStatus, err2
 	}
 	res := fmt.Sprintf("%v", targetVMI.Status.Phase)
+	_, _ = checkAndReturnStatus(vmis, false) // reset the unknown timestamp
 	return res, nil
 }
 
 // Inspired from kvm.go
-func waitForVMI(vmiName, nodeName string, available bool) error {
+func waitForVMI(vmis *vmiMetaData, nodeName string, available bool) error {
+	vmiName := vmis.name
 	maxDelay := time.Minute * 5 // 5mins ?? lets keep it for now
 	delay := time.Second
 	var waited time.Duration
@@ -804,7 +816,7 @@ func waitForVMI(vmiName, nodeName string, available bool) error {
 			waited += delay
 		}
 
-		state, err := getVMIStatus(vmiName, nodeName)
+		state, err := getVMIStatus(vmis, nodeName)
 		if err != nil {
 
 			if available {
@@ -1245,7 +1257,8 @@ func setKubeToleration(timeOutSec int64) []k8sv1.Toleration {
 	return tolerations
 }
 
-func StartReplicaPodContiner(ctx kubevirtContext, rep *appsv1.ReplicaSet) error {
+func StartReplicaPodContiner(ctx kubevirtContext, vmis *vmiMetaData) error {
+	rep := vmis.repPod
 	err := getConfig(&ctx)
 	if err != nil {
 		return err
@@ -1269,7 +1282,7 @@ func StartReplicaPodContiner(ctx kubevirtContext, rep *appsv1.ReplicaSet) error 
 
 	logrus.Infof("StartReplicaPodContiner: Rep %s %s, result %v", rep.ObjectMeta.Name, opStr, result)
 
-	err = checkForReplicaPod(ctx, rep.ObjectMeta.Name)
+	err = checkForReplicaPod(ctx, vmis)
 	if err != nil {
 		logrus.Errorf("StartReplicaPodContiner: check for pod status error %v", err)
 		return err
@@ -1278,7 +1291,8 @@ func StartReplicaPodContiner(ctx kubevirtContext, rep *appsv1.ReplicaSet) error 
 	return nil
 }
 
-func checkForReplicaPod(ctx kubevirtContext, repName string) error {
+func checkForReplicaPod(ctx kubevirtContext, vmis *vmiMetaData) error {
+	repName := vmis.repPod.ObjectMeta.Name
 	var i int
 	var status string
 	var err error
@@ -1287,7 +1301,7 @@ func checkForReplicaPod(ctx kubevirtContext, repName string) error {
 		logrus.Infof("checkForReplicaPod: check(%d) wait 15 sec, %v", i, repName)
 		time.Sleep(15 * time.Second)
 
-		status, err = InfoReplicaSetContainer(ctx, repName)
+		status, err = InfoReplicaSetContainer(ctx, vmis)
 		if err != nil {
 			logrus.Infof("checkForReplicaPod: repName %s, %v", repName, err)
 		} else {
@@ -1306,8 +1320,9 @@ func checkForReplicaPod(ctx kubevirtContext, repName string) error {
 	return fmt.Errorf("checkForReplicaPod: timed out, statuus %s, err %v", status, err)
 }
 
-func InfoReplicaSetContainer(ctx kubevirtContext, repName string) (string, error) {
+func InfoReplicaSetContainer(ctx kubevirtContext, vmis *vmiMetaData) (string, error) {
 
+	repName := vmis.repPod.ObjectMeta.Name
 	err := getConfig(&ctx)
 	if err != nil {
 		return "", err
@@ -1317,17 +1332,14 @@ func InfoReplicaSetContainer(ctx kubevirtContext, repName string) (string, error
 		return "", logError("InfoReplicaSetContainer: couldn't get the pod Config: %v", err)
 	}
 
-	nodeName, ok := ctx.nodeNameMap["nodename"]
-	if !ok {
-		return "", logError("Failed to get nodeName")
-	}
-
 	pods, err := podclientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", repName),
-		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
 	})
-	if err != nil {
-		return "", logError("InfoReplicaSetContainer: couldn't get the pods: %v", err)
+	if err != nil || len(pods.Items) == 0 {
+		// we either can not talk to the kubernetes api-server or it can not find our pod
+		retStatus, err2 := checkAndReturnStatus(vmis, true)
+		logError("InfoReplicaSetContainer: couldn't get the pods: %v, return %s", err, retStatus)
+		return retStatus, err2
 	}
 
 	for _, pod := range pods.Items {
@@ -1348,11 +1360,12 @@ func InfoReplicaSetContainer(ctx kubevirtContext, repName string) (string, error
 		default:
 			res = "Scheduling"
 		}
-		logrus.Infof("InfoReplicaSetContainer: rep %s, nodeName %v, status %s", pod.ObjectMeta.Name, pod.Spec.NodeName, res)
+		logrus.Infof("InfoReplicaSetContainer: rep %s, pod nodeName %v, status %s", pod.ObjectMeta.Name, pod.Spec.NodeName, res)
 		if pod.Status.Phase != k8sv1.PodRunning {
 			continue
 		}
 
+		_, _ = checkAndReturnStatus(vmis, false) // reset the unknown timestamp
 		return res, nil
 	}
 
@@ -1705,4 +1718,27 @@ func getMyNodeUUID(ctx *kubevirtContext, nodeName string) {
 	if len(ctx.nodeNameMap) == 0 {
 		ctx.nodeNameMap["nodename"] = nodeName
 	}
+}
+
+// checkAndReturnStatus
+// when pass-in gotUnknown is true, we failed to get the kubernetes pod, return 'Unknown' for
+// the status, and if the status exceeds 5 minutes, return 'Halting' with error
+// when pass-in !goUnknown, we reset the unknown timestamp
+func checkAndReturnStatus(vmis *vmiMetaData, gotUnknown bool) (string, error) {
+	if gotUnknown {
+		if vmis.startUnknownTime.IsZero() { // first time, set the unknown timestamp
+			vmis.startUnknownTime = time.Now()
+			return "Unknown", nil
+		} else {
+			if time.Since(vmis.startUnknownTime) > unknownToHaltMinutes*time.Minute {
+				return "Halting", fmt.Errorf("Unknown status for more than 5 minute")
+			} else {
+				return "Unknown", nil
+			}
+		}
+	} else {
+		// we got the pod status, reset the unknown timestamp
+		vmis.startUnknownTime = time.Time{}
+	}
+	return "", nil
 }

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -322,10 +322,6 @@ type DomainStatus struct {
 	VirtualTPM bool
 	// if this node is the DNiD of the App
 	IsDNidNode bool
-	// handle DomainConfig Delete
-	// For kubevirt Apps, there is no need to delete the domain from the
-	// kubernetes, unless the domain is removed from configuration.
-	DomainConfigDeleted bool
 	// the device name is used for kube node name
 	// Need to pass in from domainmgr to hypervisor context commands
 	NodeName string


### PR DESCRIPTION
- removed the check for DNid for app deletion, we'll do for all
- remove the delete() and cleanup(), stop() not for kubevirt code, since we now return 'Unknown' which needs to be handled outside kubevirt
- if we don't get status for a pod/vmi, we will return 'unknown' status, but we register the starting timestamp, if longer than 5 mins, we treat this as 'Halt' status.
- remove the max wait for nodeinfo publication at the beginning of domainmgr function, we always wait, it should be there
- sime misc fixes.