### PR TITLE
Fix a crash at domainmgr not getting EdgeNodeInfo

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -159,6 +159,7 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 			parseContentInfoConfig(getconfigCtx, config)
 			parseVolumeConfig(getconfigCtx, config)
 			parseEvConfig(getconfigCtx, config)
+			parseEdgeNodeInfo(getconfigCtx, config)
 
 			// We have handled the volumes, so we can now process the app instances. But we need to check if
 			// we are in the middle of a baseOS upgrade, and if so, we need to skip processing the app instances.
@@ -176,8 +177,6 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 			parseAppInstanceConfig(getconfigCtx, config)
 
 			parseDisksConfig(getconfigCtx, config)
-
-			parseEdgeNodeInfo(getconfigCtx, config)
 
 			parsePatchEnvelopes(getconfigCtx, config)
 		}


### PR DESCRIPTION
- since the code moved to get the EdgeNodeInfo to the beginning of domainmgr startup, before onboarding, even though the EdgeNodeInfo subscribe gets triggered, but it may not have any content.
- also the check fatal is only valid for kubevirt mode.
- move the parseEdgeNodeInfo from App section to device section.