### PR TITLE
Fix a number of kube lease election issues

### DIFF
--- a/pkg/pillar/types/zedkubetypes.go
+++ b/pkg/pillar/types/zedkubetypes.go
@@ -389,3 +389,10 @@ func (ksi KubeStorageInfo) ZKubeStorageInfo() *info.KubeStorageInfo {
 	}
 	return iKsi
 }
+
+type KubeLeaseInfo struct {
+	InLeaseElection bool
+	IsStatsLeader   bool
+	LeaderIdentity  string
+	LatestChange    time.Time
+}


### PR DESCRIPTION
- when encounter errors, the previous code exit which would disable the lease election for the node. put in retry timer to retry later
- change the duration of lease to 15/60/300 seconds
- add publication of KubeLeaseInfo, otherwise it is not visable for any debugging if there is problem
- add logging when the election RunOrDid() function if it exit
- change the start/stop channel from blocking to 1 buffer, the previous code could miss the start/stop actions due to the goroutine busy and being dropped