### PR TITLE
Metrics Cleanup: Fix pvc allocated space reporting and pvc size at creation time.

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlepvcdiskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlepvcdiskmetrics.go
@@ -48,9 +48,9 @@ func createOrUpdatePvcDiskMetrics(ctx *volumemgrContext) {
 			continue
 		}
 
-		pvcMetric := lookupDiskMetric(ctx, pvcName)
+		pvcMetric := lookupDiskMetric(ctx, sdName+"-"+pvcName)
 		if pvcMetric == nil {
-			pvcMetric = &types.DiskMetric{DiskPath: pvcName, IsDir: false}
+			pvcMetric = &types.DiskMetric{DiskPath: sdName + "-" + pvcName, IsDir: false}
 		}
 		pvcMetric.ReadBytes = metric.ReadBytes
 		pvcMetric.WriteBytes = metric.WriteBytes

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -52,7 +52,7 @@ func handleVolumeModify(ctxArg interface{}, key string,
 			status.SetError(errStr, time.Now())
 			publishVolumeStatus(ctx, status)
 			updateVolumeRefStatus(ctx, status)
-			if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {
+			if err := createOrUpdateAppDiskMetrics(ctx, agentName, status); err != nil {
 				log.Errorf("handleVolumeModify(%s): exception while publishing diskmetric. %s", key, err.Error())
 			}
 			return
@@ -65,7 +65,7 @@ func handleVolumeModify(ctxArg interface{}, key string,
 		updateVolumeStatusRefCount(ctx, status)
 		publishVolumeStatus(ctx, status)
 		updateVolumeRefStatus(ctx, status)
-		if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {
+		if err := createOrUpdateAppDiskMetrics(ctx, agentName, status); err != nil {
 			log.Errorf("handleVolumeModify(%s): exception while publishing diskmetric. %s", key, err.Error())
 		}
 	}
@@ -134,7 +134,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 		status.SetError(err.Error(), time.Now())
 		publishVolumeStatus(ctx, status)
 		updateVolumeRefStatus(ctx, status)
-		if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {
+		if err := createOrUpdateAppDiskMetrics(ctx, agentName, status); err != nil {
 			log.Errorf("handleDeferredVolumeCreate(%s): exception while publishing diskmetric. %s", key, err.Error())
 		}
 		return
@@ -169,7 +169,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 		}
 		publishVolumeStatus(ctx, status)
 		updateVolumeRefStatus(ctx, status)
-		if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {
+		if err := createOrUpdateAppDiskMetrics(ctx, agentName, status); err != nil {
 			log.Errorf("handleDeferredVolumeCreate(%s): exception while publishing diskmetric. %s", key, err.Error())
 		}
 		return
@@ -180,7 +180,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 		publishVolumeStatus(ctx, status)
 		updateVolumeRefStatus(ctx, status)
 	}
-	if err := createOrUpdateAppDiskMetrics(ctx, status); err != nil {
+	if err := createOrUpdateAppDiskMetrics(ctx, agentName, status); err != nil {
 		log.Errorf("handleDeferredVolumeCreate(%s): exception while publishing diskmetric. %s", key, err.Error())
 	}
 	log.Tracef("handleDeferredVolumeCreate(%s) done", key)
@@ -329,7 +329,7 @@ func maybeSpaceAvailable(ctx *volumemgrContext) {
 		if changed {
 			publishVolumeStatus(ctx, &status)
 			updateVolumeRefStatus(ctx, &status)
-			if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+			if err := createOrUpdateAppDiskMetrics(ctx, agentName, &status); err != nil {
 				log.Errorf("maybeSpaceAvailable(%s): exception while publishing diskmetric. %s", status.Key(), err.Error())
 			}
 		}

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -64,7 +64,7 @@ func handleVolumeRefCreate(ctxArg interface{}, key string,
 		if changed {
 			publishVolumeStatus(ctx, vs)
 			updateVolumeRefStatus(ctx, vs)
-			if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
+			if err := createOrUpdateAppDiskMetrics(ctx, agentName, vs); err != nil {
 				log.Errorf("handleVolumeRefCreate(%s): exception while publishing diskmetric. %s",
 					status.Key(), err.Error())
 			}
@@ -96,7 +96,7 @@ func handleVolumeRefModify(ctxArg interface{}, key string,
 		}
 		updateVolumeStatusRefCount(ctx, vs)
 		publishVolumeStatus(ctx, vs)
-		if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
+		if err := createOrUpdateAppDiskMetrics(ctx, agentName, vs); err != nil {
 			log.Errorf("handleVolumeRefModify(%s): exception while publishing diskmetric. %s",
 				status.Key(), err.Error())
 		}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -909,7 +909,7 @@ func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) bool {
 				publishVolumeStatus(ctx, &status)
 				updateVolumeRefStatus(ctx, &status)
 			}
-			if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+			if err := createOrUpdateAppDiskMetrics(ctx, agentName, &status); err != nil {
 				log.Errorf("updateVolumeStatus(%s): exception while publishing diskmetric. %s",
 					status.Key(), err.Error())
 			}
@@ -938,7 +938,7 @@ func updateVolumeStatusFromContentID(ctx *volumemgrContext, contentID uuid.UUID)
 			if changed {
 				publishVolumeStatus(ctx, &status)
 				updateVolumeRefStatus(ctx, &status)
-				if err := createOrUpdateAppDiskMetrics(ctx, &status); err != nil {
+				if err := createOrUpdateAppDiskMetrics(ctx, agentName, &status); err != nil {
 					log.Errorf("updateVolumeStatus(%s): exception while publishing diskmetric. %s",
 						status.Key(), err.Error())
 				}

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -173,7 +173,7 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 				return "", errors.New(errStr)
 			}
 
-			pvcerr := kubeapi.RolloutDiskToPVC(createContext, handler.log, false, rawImgFile, pvcName, false)
+			pvcerr := kubeapi.RolloutDiskToPVC(createContext, handler.log, false, rawImgFile, pvcName, false, pvcSize)
 
 			// Since we succeeded or failed to create PVC above, no point in keeping the rawImgFile.
 			// Delete it to save space.
@@ -198,7 +198,7 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 				return pvcName, errors.New(errStr)
 			}
 			// Convert qcow2 to PVC
-			err = kubeapi.RolloutDiskToPVC(createContext, handler.log, false, qcowFile, pvcName, false)
+			err = kubeapi.RolloutDiskToPVC(createContext, handler.log, false, qcowFile, pvcName, false, pvcSize)
 
 			if err != nil {
 				errStr := fmt.Sprintf("Error converting %s to PVC %s: %v",
@@ -244,6 +244,8 @@ func (handler *volumeHandlerCSI) DestroyVolume() (string, error) {
 func (handler *volumeHandlerCSI) Populate() (bool, error) {
 	pvcName := handler.status.GetPVCName()
 	isReplicated := handler.status.IsReplicated
+	// Kubevirt eve volumes have no location on /persist, they are PVCs
+	handler.status.FileLocation = pvcName
 	handler.log.Noticef("Populate called for PVC %s", pvcName)
 	// A replicated volume is created on designated node, this node is supposed to be a replica volume.
 	// so wait until the replica is created. It could happen that the designated node did not even receive


### PR DESCRIPTION
Allocated space is only available from lh volume object status.
PVC should be created with app inst vol defined size not img.
Set FileLocation in Populate() so its published automatically.
Fix missing VolumeStatus after modifying in volumemgr/AppDiskMetrics.

Shorter timeout set in k8s api calls for metrics path.