### PR TITLE
Fix an issue when lease renew timedout due to api-server unreachable

### DIFF
--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -100,6 +100,7 @@ type zedkubeContext struct {
 	nodeName                 string
 	isKubeStatsLeader        atomic.Bool
 	inKubeLeaderElection     atomic.Bool
+	electionFuncRunning      atomic.Bool
 	leaderIdentity           string
 	electionStartCh          chan struct{}
 	electionStopCh           chan struct{}

--- a/pkg/pillar/types/clustertypes.go
+++ b/pkg/pillar/types/clustertypes.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"net"
+	"time"
 
 	uuid "github.com/satori/go.uuid"
 )
@@ -97,3 +98,11 @@ const (
 	EncPubOpModify
 	EncPubOpDelete
 )
+
+type KubeLeaseInfo struct {
+	InLeaseElection bool
+	IsStatsLeader   bool
+	ElectionRunning bool
+	LeaderIdentity  string
+	LatestChange    time.Time
+}

--- a/pkg/pillar/types/zedkubetypes.go
+++ b/pkg/pillar/types/zedkubetypes.go
@@ -389,10 +389,3 @@ func (ksi KubeStorageInfo) ZKubeStorageInfo() *info.KubeStorageInfo {
 	}
 	return iKsi
 }
-
-type KubeLeaseInfo struct {
-	InLeaseElection bool
-	IsStatsLeader   bool
-	LeaderIdentity  string
-	LatestChange    time.Time
-}


### PR DESCRIPTION
- changed the renew deadline from 1 min to 3 mins
- added a boolean 'ElectionRunning' for lease status publication
- when lease election exit due to timed out, we need to retry to start the lease routine again