### PR TITLE
Set the content format as container for container apps

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	zconfig "github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/vault"
 	"github.com/lf-edge/eve/pkg/pillar/volumehandlers"
@@ -166,6 +167,11 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 
 		if ctStatus != nil {
 			status.ReferenceName = ctStatus.ReferenceID()
+
+			// Though we created PVC from container image, we still set the format as container.
+			if ctStatus.Format == zconfig.Format_CONTAINER {
+				status.ContentFormat = ctStatus.Format
+			}
 		}
 		publishVolumeStatus(ctx, status)
 		updateVolumeRefStatus(ctx, status)

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -246,6 +246,13 @@ func (handler *volumeHandlerCSI) Populate() (bool, error) {
 	isReplicated := handler.status.IsReplicated
 	// Kubevirt eve volumes have no location on /persist, they are PVCs
 	handler.status.FileLocation = pvcName
+	// Though we convert container image to PVC, we need to keep the image format to tell domainmgr
+	// that we are launching a container as VM.
+	if !handler.status.IsContainer() {
+		handler.status.ContentFormat = zconfig.Format_PVC
+	} else {
+		handler.status.ContentFormat = zconfig.Format_CONTAINER
+	}
 	handler.log.Noticef("Populate called for PVC %s", pvcName)
 	// A replicated volume is created on designated node, this node is supposed to be a replica volume.
 	// so wait until the replica is created. It could happen that the designated node did not even receive


### PR DESCRIPTION
When we reboot the node and restart the container app, we need to set the content format to container to launch it as shim VM.  Though we convert the container image to PVC, we still need to set the format as container.

This is day one bug, which is caught now !

I tested multiple restarts and container vmi starts fine and I was able to access it through VNC